### PR TITLE
Add new throwOnMissingStub method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* Add a new `throwOnMissingStub` method to the API.
+
 ## 2.0.0
 
 * Removed `mockito_no_mirrors.dart`
@@ -9,7 +13,6 @@
   going forward.
 * Deprecated `mockito_no_mirrors.dart`; replace with `mockito.dart`.
 * Require Dart SDK `>=1.21.0 <2.0.0` to use generic methods.
-* Add a new `throwOnMissingStub` method to the API.
 
 ## 1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   going forward.
 * Deprecated `mockito_no_mirrors.dart`; replace with `mockito.dart`.
 * Require Dart SDK `>=1.21.0 <2.0.0` to use generic methods.
+* Add a new `throwOnMissingStub` method to the API.
 
 ## 1.0.1
 

--- a/README.md
+++ b/README.md
@@ -179,8 +179,10 @@ expect(cat.lives, 9);
 
 ## Debugging
 ```dart
-//printing all collected invocations of any mock methods of a list of mock objects
+//print all collected invocations of any mock methods of a list of mock objects
 logInvocations([catOne, catTwo]);
+//throw every time that a mock method is called without a stub being matched
+throwOnMissingStub(cat);
 ```
 
 ## Strong mode compliance

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -32,6 +32,10 @@ void setDefaultResponse(Mock mock, CannedResponse defaultResponse()) {
   mock._defaultResponse = defaultResponse;
 }
 
+throwOnMissingStub(Mock mock) {
+  mock._defaultResponse = Mock._throwResponse;
+}
+
 /// Extend or mixin this class to mark the implementation as a [Mock].
 ///
 /// A mocked class implements all fields and methods with a default
@@ -64,9 +68,16 @@ void setDefaultResponse(Mock mock, CannedResponse defaultResponse()) {
 /// used within the context of Dart for Web (dart2js/ddc) and Dart for Mobile
 /// (flutter).
 class Mock {
-  static CannedResponse _nullResponse() {
-    return new CannedResponse(null, (_) => null);
-  }
+  static CannedResponse _nullResponse() =>
+      new CannedResponse(null, (_) => null);
+
+  static CannedResponse _throwResponse() => new CannedResponse(
+      null,
+      (Invocation inv) =>
+          throw new UnimplementedError('''No stub for invocation:
+    member name: ${inv.memberName}
+    positional arguments (${inv.positionalArguments.length}): ${inv.positionalArguments}
+    named arguments (${inv.namedArguments.length}): ${inv.namedArguments}'''));
 
   final List<RealCall> _realCalls = <RealCall>[];
   final List<CannedResponse> _responses = <CannedResponse>[];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 2.0.0
+version: 2.0.1
 authors:
   - Dmitriy Fibulwinter <fibulwinter@gmail.com>
   - Dart Team <misc@dartlang.org>

--- a/test/mockito_test.dart
+++ b/test/mockito_test.dart
@@ -620,13 +620,14 @@ void main() {
 
   group("throwOnMissingStub", () {
     test("should throw when a mock was called without a matching stub", () {
-      throwOnMissingStub(mock);
+      throwOnMissingStub(mock as Mock);
       when(mock.methodWithNormalArgs(42)).thenReturn("Ultimate Answer");
-      expect(() => mock.methodWithourArgs(), throwsUnimplementedError);
+      expect(() => (mock as MockedClass).methodWithoutArgs(),
+          throwsUnimplementedError);
     });
 
     test("should not throw when a mock was called with a matching stub", () {
-      throwOnMissingStub(mock);
+      throwOnMissingStub(mock as Mock);
       when(mock.methodWithoutArgs()).thenReturn("A");
       expect(() => mock.methodWithoutArgs(), returnsNormally);
     });

--- a/test/mockito_test.dart
+++ b/test/mockito_test.dart
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import 'package:mockito/mockito.dart';
-import 'package:mockito/src/mock.dart' show resetMockitoState;
+import 'package:mockito/src/mock.dart'
+    show resetMockitoState, throwOnMissingStub;
 import 'package:test/test.dart';
 
 class RealClass {
@@ -614,6 +615,20 @@ void main() {
       mock.methodWithNormalArgs(2);
       expect(verify(mock.methodWithNormalArgs(captureAny)).captured,
           equals([1, 2]));
+    });
+  });
+
+  group("throwOnMissingStub", () {
+    test("should throw when a mock was called without a matching stub", () {
+      throwOnMissingStub(mock);
+      when(mock.methodWithNormalArgs(42)).thenReturn("Ultimate Answer");
+      expect(() => mock.methodWithourArgs(), throwsUnimplementedError);
+    });
+
+    test("should not throw when a mock was called with a matching stub", () {
+      throwOnMissingStub(mock);
+      when(mock.methodWithoutArgs()).thenReturn("A");
+      expect(() => mock.methodWithoutArgs(), returnsNormally);
     });
   });
 }


### PR DESCRIPTION
Fixes #47 

Mostly. It'd be nice to have a global one too, but this was simple to implement for now.