### PR TITLE
Throw when using when within when

### DIFF
--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -640,6 +640,9 @@ void verifyZeroInteractions(var mock) {
 typedef PostExpectation Expectation(x);
 
 Expectation get when {
+  if (_whenCall != null) {
+    throw new StateError('Cannot call `when` within a stub response');
+  }
   _whenInProgress = true;
   return (_) {
     _whenInProgress = false;

--- a/test/mockito_test.dart
+++ b/test/mockito_test.dart
@@ -18,6 +18,7 @@ import 'package:mockito/src/mock.dart'
 import 'package:test/test.dart';
 
 class RealClass {
+  RealClass innerObj;
   String methodWithoutArgs() => "Real";
   String methodWithNormalArgs(int x) => "Real";
   String methodWithListArgs(List<int> x) => "Real";
@@ -218,6 +219,18 @@ void main() {
       when(mock.methodWithNormalArgs(argThat(equals(42)))).thenReturn("42");
       expect(mock.methodWithNormalArgs(43), equals("43"));
     });
+    test("should throw if `when` is called while stubbing", () {
+      expect(() {
+        var responseHelper = () {
+          var mock2 = new MockedClass();
+          when(mock2.getter).thenReturn("A");
+          return mock2;
+        };
+        when(mock.innerObj).thenReturn(responseHelper());
+      }, throwsStateError);
+    });
+
+    // [typed] API
     test("should mock method with typed arg matchers", () {
       when(mock.typeParameterizedFn(typed(any), typed(any)))
           .thenReturn("A lot!");


### PR DESCRIPTION
Calling `when` within a stub response has always been illegal, but has always unhelpfully just resulted in `NoSuchMethodError: The method '_setExpected' was called on null.`. This change throws a more helpful error.

Example in the tests.