### PR TITLE
Add ability to wait for an invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,16 @@ cat.eatFood("Fish");
 expect(verify(cat.eatFood(captureThat(startsWith("F")).captured, ["Fish"]);
 ```
 
+## Waiting for an interaction
+```dart
+//waiting for a call
+cat.eatFood("Fish");
+await untilCalled(cat.chew()); //completes when cat.chew() is called
+//waiting for a call that has already happened
+cat.eatFood("Fish");
+await untilCalled(cat.eatFood(any)); //will complete immediately
+```
+
 ## Resetting mocks
 ```dart
 //clearing collected interactions

--- a/lib/mockito.dart
+++ b/lib/mockito.dart
@@ -42,4 +42,5 @@ export 'src/mock.dart'
         clearInteractions,
         reset,
         resetMockitoState,
-        logInvocations;
+        logInvocations,
+        untilCalled;

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -15,14 +15,18 @@
 // Warning: Do not import dart:mirrors in this library, as it's exported via
 // lib/mockito.dart, which is used for Dart AOT projects such as Flutter.
 
+import 'dart:async';
+
 import 'package:meta/meta.dart';
 import 'package:mockito/src/call_pair.dart';
 import 'package:mockito/src/invocation_matcher.dart';
 import 'package:test/test.dart';
 
 bool _whenInProgress = false;
+bool _waitForInProgress = false;
 bool _verificationInProgress = false;
 _WhenCall _whenCall;
+_WaitForCall _waitForCall;
 final List<_VerifyCall> _verifyCalls = <_VerifyCall>[];
 final _TimeStampProvider _timer = new _TimeStampProvider();
 final List _capturedArgs = [];
@@ -78,6 +82,8 @@ class Mock {
 
   static const _nullResponse = const CallPair.allInvocations(_answerNull);
 
+  final StreamController<Invocation> _invocationStreamController =
+      new StreamController.broadcast();
   final _realCalls = <RealCall>[];
   final _responses = <CallPair>[];
 
@@ -103,8 +109,12 @@ class Mock {
     } else if (_verificationInProgress) {
       _verifyCalls.add(new _VerifyCall(this, invocation));
       return null;
+    } else if (_waitForInProgress) {
+      _waitForCall = new _WaitForCall(this, invocation);
+      return null;
     } else {
       _realCalls.add(new RealCall(this, invocation));
+      _invocationStreamController.add(invocation);
       var cannedResponse = _responses.lastWhere(
           (cr) => cr.call.matches(invocation, {}),
           orElse: _defaultResponse);
@@ -470,6 +480,29 @@ class _WhenCall {
   }
 }
 
+class _WaitForCall {
+  final InvocationMatcher _invocationMatcher;
+  final Mock _mock;
+
+  _WaitForCall(this._mock, Invocation invocation)
+      : _invocationMatcher = new InvocationMatcher(invocation);
+
+  bool _matchesInvocation(RealCall realCall) =>
+      _invocationMatcher.matches(realCall.invocation);
+
+  List<RealCall> get _realCalls => _mock._realCalls;
+
+  Future<Invocation> get invocationFuture {
+    if (_realCalls.any(_matchesInvocation)) {
+      return new Future.value(
+          _realCalls.firstWhere(_matchesInvocation).invocation);
+    }
+
+    return _mock._invocationStreamController.stream
+        .firstWhere(_invocationMatcher.matches);
+  }
+}
+
 class _VerifyCall {
   final Mock mock;
   final Invocation verifyInvocation;
@@ -704,6 +737,29 @@ Expectation get when {
   return (_) {
     _whenInProgress = false;
     return new PostExpectation();
+  };
+}
+
+typedef Future<Invocation> InvocationLoader(_);
+
+/// Returns a future [Invocation] that will complete upon the first occurrence
+/// of the given invocation.
+///
+/// Usage of this is as follows:
+///
+/// ```dart
+/// cat.eatFood("fish");
+/// await waitFor(cat.chew());
+/// ```
+///
+/// In the above example, the waitFor(cat.chew()) will complete only when that
+/// method is called. If the given invocation has already been called, the
+/// future will return immediately.
+InvocationLoader get waitFor {
+  _waitForInProgress = true;
+  return (_) {
+    _waitForInProgress = false;
+    return _waitForCall.invocationFuture;
   };
 }
 

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -23,10 +23,10 @@ import 'package:mockito/src/invocation_matcher.dart';
 import 'package:test/test.dart';
 
 bool _whenInProgress = false;
-bool _waitForInProgress = false;
+bool _untilCalledInProgress = false;
 bool _verificationInProgress = false;
 _WhenCall _whenCall;
-_WaitForCall _waitForCall;
+_UntilCall _untilCall;
 final List<_VerifyCall> _verifyCalls = <_VerifyCall>[];
 final _TimeStampProvider _timer = new _TimeStampProvider();
 final List _capturedArgs = [];
@@ -109,8 +109,8 @@ class Mock {
     } else if (_verificationInProgress) {
       _verifyCalls.add(new _VerifyCall(this, invocation));
       return null;
-    } else if (_waitForInProgress) {
-      _waitForCall = new _WaitForCall(this, invocation);
+    } else if (_untilCalledInProgress) {
+      _untilCall = new _UntilCall(this, invocation);
       return null;
     } else {
       _realCalls.add(new RealCall(this, invocation));
@@ -480,11 +480,11 @@ class _WhenCall {
   }
 }
 
-class _WaitForCall {
+class _UntilCall {
   final InvocationMatcher _invocationMatcher;
   final Mock _mock;
 
-  _WaitForCall(this._mock, Invocation invocation)
+  _UntilCall(this._mock, Invocation invocation)
       : _invocationMatcher = new InvocationMatcher(invocation);
 
   bool _matchesInvocation(RealCall realCall) =>
@@ -749,17 +749,17 @@ typedef Future<Invocation> InvocationLoader(_);
 ///
 /// ```dart
 /// cat.eatFood("fish");
-/// await waitFor(cat.chew());
+/// await untilCalled(cat.chew());
 /// ```
 ///
-/// In the above example, the waitFor(cat.chew()) will complete only when that
-/// method is called. If the given invocation has already been called, the
+/// In the above example, the untilCalled(cat.chew()) will complete only when
+/// that method is called. If the given invocation has already been called, the
 /// future will return immediately.
-InvocationLoader get waitFor {
-  _waitForInProgress = true;
+InvocationLoader get untilCalled {
+  _untilCalledInProgress = true;
   return (_) {
-    _waitForInProgress = false;
-    return _waitForCall.invocationFuture;
+    _untilCalledInProgress = false;
+    return _untilCall.invocationFuture;
   };
 }
 
@@ -784,8 +784,10 @@ void logInvocations(List<Mock> mocks) {
 /// or in `tearDown`.
 void resetMockitoState() {
   _whenInProgress = false;
+  _untilCalledInProgress = false;
   _verificationInProgress = false;
   _whenCall = null;
+  _untilCall = null;
   _verifyCalls.clear();
   _capturedArgs.clear();
   _typedArgs.clear();


### PR DESCRIPTION
Adding a way to wait for an invocation. This is particularly useful when testing event based functionality where there is no easy way to await the expected behavior.