### PR TITLE
Bump to 2.2.0; add collection dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.0
+
+* Add new feature to wait for an interaction: `untilCalled`. See the README for
+  documentation.
+
 ## 2.1.0
 
 * Add documentation for `when`, `verify`, `verifyNever`, `resetMockitoState`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 2.1.0
+version: 2.2.0
 authors:
   - Dmitriy Fibulwinter <fibulwinter@gmail.com>
   - Dart Team <misc@dartlang.org>
@@ -8,6 +8,7 @@ homepage: https://github.com/dart-lang/mockito
 environment:
   sdk: '>=1.21.0 <2.0.0-dev.infinity'
 dependencies:
+  collection: '^1.1.0'
   matcher: '^0.12.0'
   meta: '^1.0.4'
   test: '>=0.12.0 <0.13.0'


### PR DESCRIPTION
`collection` has been depended on transitively; this makes that explicit.