### PR TITLE
Update the link of Mockito for Java in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Mock library for Dart inspired by [Mockito](https://code.google.com/p/mockito/).
+Mock library for Dart inspired by [Mockito](https://github.com/mockito/mockito).
 
 [![Pub](https://img.shields.io/pub/v/mockito.svg)]()
 [![Build Status](https://travis-ci.org/dart-lang/mockito.svg?branch=master)](https://travis-ci.org/dart-lang/mockito)


### PR DESCRIPTION
Mockito for Java was migrated from Google Code to GitHub.