### PR TITLE
Throw an ArgumentError if `thenReturn` is called with futures or streams.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.3.0
 
-* `thenReturn` now asserts that neither a `Future` nor `Stream` is provided.
-  `thenReturn` calls with futures and streams should be changed to
+* `thenReturn` now throws an `ArgumentError` if either a `Future` or `Stream`
+  is provided. `thenReturn` calls with futures and streams should be changed to
   `thenAnswer`. See the README for more information.
 
 ## 2.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.3.0
+
+* `thenReturn` now asserts that neither a `Future` nor `Stream` is provided.
+  `thenReturn` calls with futures and streams should be changed to
+  `thenAnswer`. See the README for more information.
+
 ## 2.2.0
 
 * Add new feature to wait for an interaction: `untilCalled`. See the README for

--- a/README.md
+++ b/README.md
@@ -90,6 +90,45 @@ the same arguments many times. In other words: the order of stubbing matters,
 but it is meaningful rarely, e.g. when stubbing exactly the same method calls
 or sometimes when argument matchers are used, etc.
 
+### A quick word on async stubbing
+
+**Using `thenReturn` to return a `Future` or `Stream` will throw an assertion
+error.** This is because it can lead to unexpected behaviors. For example:
+
+* If the method is stubbed in a different zone than the zone that consumes the
+  `Future`, unexpected behavior could occur.
+* If the method is stubbed to return a failed `Future` or `Stream` and it
+  doesn't get consumed in the same run loop, it might get consumed by the
+  global exception handler instead of an exception handler the consumer applies.
+
+Instead, use `thenAnswer` to stub methods that return a `Future` or `Stream`.
+
+```
+// BAD
+when(mock.methodThatReturnsAFuture())
+    .thenReturn(new Future.value('Stub'));
+when(mock.methodThatReturnsAStream())
+    .thenReturn(new Stream.fromIterable(['Stub']));
+
+// GOOD
+when(mock.methodThatReturnsAFuture())
+    .thenAnswer((_) => new Future.value('Stub'));
+when(mock.methodThatReturnsAStream())
+    .thenAnswer((_) => new Stream.fromIterable(['Stub']));
+
+````
+
+If, for some reason, you desire the behavior of `thenReturn`, you can return a
+pre-defined instance.
+
+```
+// Use the above method unless you're sure you want to create the Future ahead
+// of time.
+final future = new Future.value('Stub');
+when(mock.methodThatReturnsAFuture()).thenAnswer((_) => future);
+```
+
+
 ## Argument matchers
 
 ```dart

--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ or sometimes when argument matchers are used, etc.
 
 ### A quick word on async stubbing
 
-**Using `thenReturn` to return a `Future` or `Stream` will throw an assertion
-error.** This is because it can lead to unexpected behaviors. For example:
+**Using `thenReturn` to return a `Future` or `Stream` will throw an
+`ArgumentError`.** This is because it can lead to unexpected behaviors. For
+example:
 
 * If the method is stubbed in a different zone than the zone that consumes the
   `Future`, unexpected behavior could occur.

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -301,14 +301,16 @@ void clearInteractions(var mock) {
 
 class PostExpectation {
   thenReturn(expected) {
-    assert(
-        expected is! Future,
-        '`thenReturn` should not be used to return a Future. '
-        'Instead, use `thenAnswer((_) => future)`.');
-    assert(
-        expected is! Stream,
-        '`thenReturn` should not be used to return a Stream. '
-        'Instead, use `thenAnswer((_) => stream)`.');
+    if (expected is Future) {
+      throw new ArgumentError(
+          '`thenReturn` should not be used to return a Future. '
+          'Instead, use `thenAnswer((_) => future)`.');
+    }
+    if (expected is Stream) {
+      throw new ArgumentError(
+          '`thenReturn` should not be used to return a Stream. '
+          'Instead, use `thenAnswer((_) => stream)`.');
+    }
     return _completeWhen((_) => expected);
   }
 

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -301,6 +301,14 @@ void clearInteractions(var mock) {
 
 class PostExpectation {
   thenReturn(expected) {
+    assert(
+        expected is! Future,
+        '`thenReturn` should not be used to return a Future. '
+        'Instead, use `thenAnswer((_) => future)`.');
+    assert(
+        expected is! Stream,
+        '`thenReturn` should not be used to return a Stream. '
+        'Instead, use `thenAnswer((_) => stream)`.');
     return _completeWhen((_) => expected);
   }
 

--- a/test/mockito_test.dart
+++ b/test/mockito_test.dart
@@ -292,14 +292,14 @@ void main() {
       expect(
           () => when(mock.methodReturningFuture())
               .thenReturn(new Future.value("stub")),
-          throwsA(new isInstanceOf<AssertionError>()));
+          throwsArgumentError);
     });
 
     test("thenReturn throws if provided Stream", () {
       expect(
           () => when(mock.methodReturningStream())
               .thenReturn(new Stream.fromIterable(["stub"])),
-          throwsA(new isInstanceOf<AssertionError>()));
+          throwsArgumentError);
     });
 
     test("thenAnswer supports stubbing method returning a Future", () async {

--- a/test/mockito_test.dart
+++ b/test/mockito_test.dart
@@ -28,6 +28,8 @@ class RealClass {
   String methodWithNamedArgs(int x, {int y}) => "Real";
   String methodWithTwoNamedArgs(int x, {int y, int z}) => "Real";
   String methodWithObjArgs(RealClass x) => "Real";
+  Future<String> methodReturningFuture() => new Future.value("Real");
+  Stream<String> methodReturningStream() => new Stream.fromIterable(["Real"]);
   // "SpecialArgs" here means type-parameterized args. But that makes for a long
   // method name.
   String typeParameterizedFn(List<int> w, List<int> x,
@@ -284,6 +286,34 @@ void main() {
         };
         when(mock.innerObj).thenReturn(responseHelper());
       }, throwsStateError);
+    });
+
+    test("thenReturn throws if provided Future", () {
+      expect(
+          () => when(mock.methodReturningFuture())
+              .thenReturn(new Future.value("stub")),
+          throwsA(new isInstanceOf<AssertionError>()));
+    });
+
+    test("thenReturn throws if provided Stream", () {
+      expect(
+          () => when(mock.methodReturningStream())
+              .thenReturn(new Stream.fromIterable(["stub"])),
+          throwsA(new isInstanceOf<AssertionError>()));
+    });
+
+    test("thenAnswer supports stubbing method returning a Future", () async {
+      when(mock.methodReturningFuture())
+          .thenAnswer((_) => new Future.value("stub"));
+
+      expect(await mock.methodReturningFuture(), "stub");
+    });
+
+    test("thenAnswer supports stubbing method returning a Stream", () async {
+      when(mock.methodReturningStream())
+          .thenAnswer((_) => new Stream.fromIterable(["stub"]));
+
+      expect(await mock.methodReturningStream().toList(), ["stub"]);
     });
 
     // [typed] API


### PR DESCRIPTION
Also, documented this behavior in the README.

This fixes #79.