### PR TITLE
Capture T in `verify`+ so T may be `void` in dart 2: `verify(m.void())`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: dart
 sudo: false
 dart:
-  - stable
   - dev
 script: ./tool/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,4 @@ sudo: false
 dart:
   - stable
   - dev
-  - 1.21.1
 script: ./tool/travis.sh

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -607,12 +607,8 @@ class VerificationResult {
 
 typedef dynamic Answering(Invocation realInvocation);
 
-/// Future-proofing: `<T>` may, in dart 2, allow assignment of "void", so that
-/// you can do `verify(m.voidFn())`. Subject to change.
 typedef Verification = VerificationResult Function<T>(T matchingInvocations);
 
-/// Future-proofing: `<T>` may, in dart 2, allow assignment of "void", so that
-/// you can do `verifyInOrder([m.voidFn(), m.voidFnToo()])`. Subject to change.
 typedef _InOrderVerification = void Function<T>(List<T> recordedInvocations);
 
 /// Verify that a method on a mock object was never called with the given
@@ -724,8 +720,6 @@ void verifyZeroInteractions(var mock) {
   }
 }
 
-/// Future-proofing: `<T>` may, in dart 2, allow assignment of "void", so that
-/// you can do `when(m.voidFn()).thenAnswer(...)`. Subject to change.
 typedef Expectation = PostExpectation Function<T>(T x);
 
 /// Create a stub method response.

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -750,7 +750,7 @@ Expectation get when {
   };
 }
 
-typedef Future<Invocation> InvocationLoader(_);
+typedef InvocationLoader = Future<Invocation> Function<T>(T _);
 
 /// Returns a future [Invocation] that will complete upon the first occurrence
 /// of the given invocation.
@@ -767,7 +767,7 @@ typedef Future<Invocation> InvocationLoader(_);
 /// future will return immediately.
 InvocationLoader get untilCalled {
   _untilCalledInProgress = true;
-  return (_) {
+  return <T>(T _) {
     _untilCalledInProgress = false;
     return _untilCall.invocationFuture;
   };

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -607,9 +607,13 @@ class VerificationResult {
 
 typedef dynamic Answering(Invocation realInvocation);
 
-typedef VerificationResult Verification(matchingInvocations);
+/// Future-proofing: `<T>` may, in dart 2, allow assignment of "void", so that
+/// you can do `verify(m.voidFn())`. Subject to change.
+typedef Verification = VerificationResult Function<T>(T matchingInvocations);
 
-typedef void _InOrderVerification(List<dynamic> recordedInvocations);
+/// Future-proofing: `<T>` may, in dart 2, allow assignment of "void", so that
+/// you can do `verifyInOrder([m.voidFn(), m.voidFnToo()])`. Subject to change.
+typedef _InOrderVerification = void Function<T>(List<T> recordedInvocations);
 
 /// Verify that a method on a mock object was never called with the given
 /// arguments.
@@ -655,7 +659,7 @@ Verification _makeVerify(bool never) {
     throw new StateError(_verifyCalls.join());
   }
   _verificationInProgress = true;
-  return (mock) {
+  return <T>(T mock) {
     _verificationInProgress = false;
     if (_verifyCalls.length == 1) {
       _VerifyCall verifyCall = _verifyCalls.removeLast();
@@ -674,7 +678,7 @@ _InOrderVerification get verifyInOrder {
     throw new StateError(_verifyCalls.join());
   }
   _verificationInProgress = true;
-  return (List<dynamic> _) {
+  return <T>(List<T> _) {
     _verificationInProgress = false;
     DateTime dt = new DateTime.fromMillisecondsSinceEpoch(0);
     var tmpVerifyCalls = new List<_VerifyCall>.from(_verifyCalls);
@@ -720,7 +724,9 @@ void verifyZeroInteractions(var mock) {
   }
 }
 
-typedef PostExpectation Expectation(x);
+/// Future-proofing: `<T>` may, in dart 2, allow assignment of "void", so that
+/// you can do `when(m.voidFn()).thenAnswer(...)`. Subject to change.
+typedef Expectation = PostExpectation Function<T>(T x);
 
 /// Create a stub method response.
 ///
@@ -744,7 +750,7 @@ Expectation get when {
     throw new StateError('Cannot call `when` within a stub response');
   }
   _whenInProgress = true;
-  return (_) {
+  return <T>(T _) {
     _whenInProgress = false;
     return new PostExpectation();
   };

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ authors:
 description: A mock framework inspired by Mockito.
 homepage: https://github.com/dart-lang/mockito
 environment:
-  sdk: '>=1.21.0 <2.0.0'
+  sdk: '>=2.0.0-dev.16.0 <2.0.0'
 dependencies:
   collection: '^1.1.0'
   matcher: '^0.12.0'


### PR DESCRIPTION
While the semantics here are not yet fully decided, it is likely that
dart 2 will disallow passing void into dynamic. The most backwards
compatible solution here is to parameterize meta function types over T
so that the type `void` is inferred, *possibly* allowing the result of a
void method to be passed in.

This change unblocks us for incrementally rolling out the new void
semantics.

It may in fact require a change to specify the `void` type directly,
rather than allowing `T` to be void for any `T`, but for now that's not
required and would hurt backwards compatibility since `void` didn't used
to be allowed there.

It also may not be allowed at all under any case, in which case we'd be
in for a fun ride.