### PR TITLE
verify*Interactions methods throw helpfully that they expect Mock

### DIFF
--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -710,18 +710,24 @@ void _throwMockArgumentError(method) =>
     throw new ArgumentError('$method must only be given a Mock object');
 
 void verifyNoMoreInteractions(var mock) {
-  if (mock is! Mock) _throwMockArgumentError('verifyNoMoreInteractions');
-  var unverified = mock._realCalls.where((inv) => !inv.verified).toList();
-  if (unverified.isNotEmpty) {
-    fail("No more calls expected, but following found: " + unverified.join());
+  if (mock is Mock) {
+    var unverified = mock._realCalls.where((inv) => !inv.verified).toList();
+    if (unverified.isNotEmpty) {
+      fail("No more calls expected, but following found: " + unverified.join());
+    }
+  } else {
+    _throwMockArgumentError('verifyNoMoreInteractions');
   }
 }
 
 void verifyZeroInteractions(var mock) {
-  if (mock is! Mock) _throwMockArgumentError('verifyZeroInteractions');
-  if (mock._realCalls.isNotEmpty) {
-    fail("No interaction expected, but following found: " +
-        mock._realCalls.join());
+  if (mock is Mock) {
+    if (mock._realCalls.isNotEmpty) {
+      fail("No interaction expected, but following found: " +
+          mock._realCalls.join());
+    }
+  } else {
+    _throwMockArgumentError('verifyZeroInteractions');
   }
 }
 

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -706,7 +706,10 @@ _InOrderVerification get verifyInOrder {
   };
 }
 
+void _throwMockArgumentError(method) => throw new ArgumentError('$method must only be given a Mock object');
+
 void verifyNoMoreInteractions(var mock) {
+  if (mock is! Mock) _throwMockArgumentError('verifyNoMoreInteractions');
   var unverified = mock._realCalls.where((inv) => !inv.verified).toList();
   if (unverified.isNotEmpty) {
     fail("No more calls expected, but following found: " + unverified.join());
@@ -714,6 +717,7 @@ void verifyNoMoreInteractions(var mock) {
 }
 
 void verifyZeroInteractions(var mock) {
+  if (mock is! Mock) _throwMockArgumentError('verifyZeroInteractions');
   if (mock._realCalls.isNotEmpty) {
     fail("No interaction expected, but following found: " +
         mock._realCalls.join());

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -706,7 +706,8 @@ _InOrderVerification get verifyInOrder {
   };
 }
 
-void _throwMockArgumentError(method) => throw new ArgumentError('$method must only be given a Mock object');
+void _throwMockArgumentError(method) =>
+    throw new ArgumentError('$method must only be given a Mock object');
 
 void verifyNoMoreInteractions(var mock) {
   if (mock is! Mock) _throwMockArgumentError('verifyNoMoreInteractions');

--- a/test/mockito_test.dart
+++ b/test/mockito_test.dart
@@ -936,6 +936,11 @@ void main() {
       verify(mock.methodWithoutArgs());
       verifyNoMoreInteractions(mock);
     });
+
+    test("throws if given a real object", () {
+      expect(
+          () => verifyNoMoreInteractions(new RealClass()), throwsArgumentError);
+    });
   });
 
   group("verifyInOrder()", () {


### PR DESCRIPTION
So, the alternative is to Use-The-Damn-Language-Like-You're-S'posed-To-™ and type the incoming argument.

However, when playing around with this internally, I think it actually gets in the way a lot. You see this a lot:

```dart
main() {
  HttpClient httpClient;

  setUp(() {
    httpClient = new MockHttpClient();
  });

  test('foo', () {
    // ...
    verifyZeroInteractions(httpClient);
  });
}

class MockHttpClient extends Mock implements HttpClient {}
```

Which would start throwing static analysis errors, because `httpClient` is declared as a `HttpClient`, not a `Mock`. You'd have to change the type at the declaration to `MockHttpClient`.

(A) This would be a lot of work to upgrade existing code, for little benefit. (B) I think this produces more overhead for a developer than is helpful: you want to think of your mock objects as really almost basically just the same thing as the type they are mocking. Typing all your mock objects to the type that they implement is intuitive (it's done everywhere).