### PR TITLE
Bump to 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.2.2
+
+* Remove last violation of `USES_DYNAMIC_AS_BOTTOM` error. This should make
+  Mockito compatible with Dart 2 semantics.
+
+## 2.2.1
+
+* Internal fixes only (stop using comment-based generic method syntax).
+
 ## 2.2.0
 
 * Add new feature to wait for an interaction: `untilCalled`. See the README for

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 2.2.1
+version: 2.2.2
 authors:
   - Dmitriy Fibulwinter <fibulwinter@gmail.com>
   - Dart Team <misc@dartlang.org>


### PR DESCRIPTION
I've made a branch (naming is hard; it's called `two-two-one-plus`) for a quick 2.2.2 release for Flutter, for https://github.com/flutter/flutter/issues/14532.

@a-siva thinks we just need the USES_DYNAMIC_AS_BOTTOM fix, the only commit in this branch after the 2.2.1 bump.

(And I hope this is the "correct" way to patch "old" releases like this...)