### PR TITLE
Generic support for `thenReturn` and `thenAnswer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
   is provided. `thenReturn` calls with futures and streams should be changed to
   `thenAnswer`. See the README for more information.
 * Completely remove the mirrors implementation of Mockito (`mirrors.dart`).
+* `thenReturn` and `thenAnswer` now support generics and infer the correct
+  types from the `when` call.
+
 
 ## 2.2.0
 

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -296,8 +296,8 @@ void clearInteractions(var mock) {
   mock._realCalls.clear();
 }
 
-class PostExpectation {
-  thenReturn(expected) {
+class PostExpectation<T> {
+  T thenReturn(T expected) {
     if (expected is Future) {
       throw new ArgumentError(
           '`thenReturn` should not be used to return a Future. '
@@ -317,7 +317,7 @@ class PostExpectation {
     });
   }
 
-  thenAnswer(Answering answer) {
+  T thenAnswer(Answering<T> answer) {
     return _completeWhen(answer);
   }
 
@@ -602,7 +602,7 @@ class VerificationResult {
   }
 }
 
-typedef dynamic Answering(Invocation realInvocation);
+typedef T Answering<T>(Invocation realInvocation);
 
 typedef Verification = VerificationResult Function<T>(T matchingInvocations);
 
@@ -717,7 +717,7 @@ void verifyZeroInteractions(var mock) {
   }
 }
 
-typedef Expectation = PostExpectation Function<T>(T x);
+typedef Expectation = PostExpectation<T> Function<T>(T x);
 
 /// Create a stub method response.
 ///
@@ -743,7 +743,7 @@ Expectation get when {
   _whenInProgress = true;
   return <T>(T _) {
     _whenInProgress = false;
-    return new PostExpectation();
+    return new PostExpectation<T>();
   };
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 3.0.0-alpha
+version: 3.0.0
 authors:
   - Dmitriy Fibulwinter <fibulwinter@gmail.com>
   - Dart Team <misc@dartlang.org>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 3.0.0
+version: 3.0.0-dev
 authors:
   - Dmitriy Fibulwinter <fibulwinter@gmail.com>
   - Dart Team <misc@dartlang.org>

--- a/test/mockito_test.dart
+++ b/test/mockito_test.dart
@@ -260,8 +260,8 @@ void main() {
     });
 
     test("should return mock to make simple oneline mocks", () {
-      RealClass mockWithSetup =
-          when(new MockedClass().methodWithoutArgs()).thenReturn("oneline");
+      RealClass mockWithSetup = new MockedClass();
+      when(mockWithSetup.methodWithoutArgs()).thenReturn("oneline");
       expect(mockWithSetup.methodWithoutArgs(), equals("oneline"));
     });
 


### PR DESCRIPTION
I have been running into these errors as I have migrated folks over to DDC. Thankfully they can be caught through analysis instead of runtime. Unfortunately, it will be a huge pain in the ass to pull into Google3. We'll see who that works lands on :P