### PR TITLE
Update travis script to actually run dartanalyzer

### DIFF
--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -28,7 +28,7 @@ echo "PASSED"
 
 # Make sure we pass the analyzer
 echo "Checking dartanalyzer..."
-FAILS_ANALYZER="$(find lib test -name "*.dart" | xargs dartanalyzer --options .analysis_options)"
+FAILS_ANALYZER="$(find lib test -name "*.dart" | xargs dartanalyzer --options analysis_options.yaml)"
 if [[ $FAILS_ANALYZER == *"[error]"* ]]
 then
   echo "FAILED"


### PR DESCRIPTION
Current dartanalyzer returns: "Options file not found: .analysis_options"
Updating the file name to point at the actual analysis options in the repo