### PR TITLE
Bump to 2.2.4 with generic thenReturn/Answer feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: dart
 sudo: false
 dart:
-  - stable
   - dev
-  - 1.21.1
 script: ./tool/travis.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.2.2
+
+* Remove last violation of `USES_DYNAMIC_AS_BOTTOM` error. This should make
+  Mockito compatible with Dart 2 semantics.
+
+## 2.2.1
+
+* Internal fixes only (stop using comment-based generic method syntax).
+
 ## 2.2.0
 
 * Add new feature to wait for an interaction: `untilCalled`. See the README for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.3
+
+* Avoid generlized void isses. Fixes Mockito's compliance with Dart SDK
+  2.0.0-dev.23.0.
+
 ## 2.2.2
 
 * Remove last violation of `USES_DYNAMIC_AS_BOTTOM` error. This should make

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.4
+
+* `thenReturn` and `thenAnswer` now support generics and infer the correct
+  types from the `when` call.
+
 ## 2.2.3
 
 * Avoid generlized void isses. Fixes Mockito's compliance with Dart SDK

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -667,7 +667,7 @@ _InOrderVerification get verifyInOrder {
   return (List<dynamic> _) {
     _verificationInProgress = false;
     DateTime dt = new DateTime.fromMillisecondsSinceEpoch(0);
-    var tmpVerifyCalls = new List.from(_verifyCalls);
+    var tmpVerifyCalls = new List<_VerifyCall>.from(_verifyCalls);
     _verifyCalls.clear();
     List<RealCall> matchedCalls = [];
     for (_VerifyCall verifyCall in tmpVerifyCalls) {

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -597,9 +597,9 @@ class VerificationResult {
 
 typedef dynamic Answering(Invocation realInvocation);
 
-typedef VerificationResult Verification(matchingInvocations);
+typedef Verification = VerificationResult Function<T>(T matchingInvocations);
 
-typedef void _InOrderVerification(List<dynamic> recordedInvocations);
+typedef _InOrderVerification = void Function<T>(List<T> recordedInvocations);
 
 /// Verify that a method on a mock object was never called with the given
 /// arguments.
@@ -645,7 +645,7 @@ Verification _makeVerify(bool never) {
     throw new StateError(_verifyCalls.join());
   }
   _verificationInProgress = true;
-  return (mock) {
+  return <T>(T mock) {
     _verificationInProgress = false;
     if (_verifyCalls.length == 1) {
       _VerifyCall verifyCall = _verifyCalls.removeLast();
@@ -664,7 +664,7 @@ _InOrderVerification get verifyInOrder {
     throw new StateError(_verifyCalls.join());
   }
   _verificationInProgress = true;
-  return (List<dynamic> _) {
+  return <T>(List<T> _) {
     _verificationInProgress = false;
     DateTime dt = new DateTime.fromMillisecondsSinceEpoch(0);
     var tmpVerifyCalls = new List<_VerifyCall>.from(_verifyCalls);
@@ -710,7 +710,7 @@ void verifyZeroInteractions(var mock) {
   }
 }
 
-typedef PostExpectation Expectation(x);
+typedef Expectation = PostExpectation Function<T>(T x);
 
 /// Create a stub method response.
 ///
@@ -734,13 +734,13 @@ Expectation get when {
     throw new StateError('Cannot call `when` within a stub response');
   }
   _whenInProgress = true;
-  return (_) {
+  return <T>(T _) {
     _whenInProgress = false;
     return new PostExpectation();
   };
 }
 
-typedef Future<Invocation> InvocationLoader(_);
+typedef InvocationLoader = Future<Invocation> Function<T>(T _);
 
 /// Returns a future [Invocation] that will complete upon the first occurrence
 /// of the given invocation.
@@ -757,7 +757,7 @@ typedef Future<Invocation> InvocationLoader(_);
 /// future will return immediately.
 InvocationLoader get untilCalled {
   _untilCalledInProgress = true;
-  return (_) {
+  return <T>(T _) {
     _untilCalledInProgress = false;
     return _untilCall.invocationFuture;
   };

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -299,8 +299,9 @@ void clearInteractions(var mock) {
   mock._realCalls.clear();
 }
 
-class PostExpectation {
-  thenReturn(expected) {
+<<<<<<< HEAD
+class PostExpectation<T> {
+  T thenReturn(T expected) {
     return _completeWhen((_) => expected);
   }
 
@@ -310,7 +311,7 @@ class PostExpectation {
     });
   }
 
-  thenAnswer(Answering answer) {
+  T thenAnswer(Answering<T> answer) {
     return _completeWhen(answer);
   }
 
@@ -595,7 +596,7 @@ class VerificationResult {
   }
 }
 
-typedef dynamic Answering(Invocation realInvocation);
+typedef T Answering<T>(Invocation realInvocation);
 
 typedef Verification = VerificationResult Function<T>(T matchingInvocations);
 
@@ -710,7 +711,7 @@ void verifyZeroInteractions(var mock) {
   }
 }
 
-typedef Expectation = PostExpectation Function<T>(T x);
+typedef Expectation = PostExpectation<T> Function<T>(T x);
 
 /// Create a stub method response.
 ///
@@ -736,7 +737,7 @@ Expectation get when {
   _whenInProgress = true;
   return <T>(T _) {
     _whenInProgress = false;
-    return new PostExpectation();
+    return new PostExpectation<T>();
   };
 }
 

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -299,7 +299,6 @@ void clearInteractions(var mock) {
   mock._realCalls.clear();
 }
 
-<<<<<<< HEAD
 class PostExpectation<T> {
   T thenReturn(T expected) {
     return _completeWhen((_) => expected);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ authors:
 description: A mock framework inspired by Mockito.
 homepage: https://github.com/dart-lang/mockito
 environment:
-  sdk: '>=1.21.0 <2.0.0'
+  sdk: '>=2.0.0-dev.16.0 <2.0.0'
 dependencies:
   collection: '^1.1.0'
   matcher: '^0.12.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 2.2.1
+version: 2.2.2
 authors:
   - Dmitriy Fibulwinter <fibulwinter@gmail.com>
   - Dart Team <misc@dartlang.org>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 2.2.2
+version: 2.2.3
 authors:
   - Dmitriy Fibulwinter <fibulwinter@gmail.com>
   - Dart Team <misc@dartlang.org>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 2.2.3
+version: 2.2.4
 authors:
   - Dmitriy Fibulwinter <fibulwinter@gmail.com>
   - Dart Team <misc@dartlang.org>

--- a/test/mockito_test.dart
+++ b/test/mockito_test.dart
@@ -258,8 +258,8 @@ void main() {
     });
 
     test("should return mock to make simple oneline mocks", () {
-      RealClass mockWithSetup =
-          when(new MockedClass().methodWithoutArgs()).thenReturn("oneline");
+      RealClass mockWithSetup = new MockedClass();
+      when(mockWithSetup.methodWithoutArgs()).thenReturn("oneline");
       expect(mockWithSetup.methodWithoutArgs(), equals("oneline"));
     });
 


### PR DESCRIPTION
This feature should prevent Open Source projects from landing code that is not allowed internally, until we are able to release 3.0.