### PR TITLE
Bump to 3.0.0-alpha+2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 3.0.0
+## 3.0.0-alpha+2
+
+* Support stubbing of void methods in Dart 2.
+
+## 3.0.0-alpha
 
 * `thenReturn` now throws an `ArgumentError` if either a `Future` or `Stream`
   is provided. `thenReturn` calls with futures and streams should be changed to

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 3.0.0-alpha
+version: 3.0.0-alpha+2
 authors:
   - Dmitriy Fibulwinter <fibulwinter@gmail.com>
   - Dart Team <misc@dartlang.org>


### PR DESCRIPTION
Just the void fix, allowing flutter to enforce the thenReturn Future/Stream behavior.