### PR TITLE
Bump to 3.0.0-alpha+3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
-## 3.0.0
+## 3.0.0-alpha+3
+
+* `thenReturn` and `thenAnswer` now support generics and infer the correct
+  types from the `when` call.
+* Completely remove the mirrors implementation of Mockito (`mirrors.dart`).
+
+## 3.0.0-alpha+2
+
+* Support stubbing of void methods in Dart 2.
+
+## 3.0.0-alpha
 
 * `thenReturn` now throws an `ArgumentError` if either a `Future` or `Stream`
   is provided. `thenReturn` calls with futures and streams should be changed to
   `thenAnswer`. See the README for more information.
-* `thenReturn` and `thenAnswer` now support generics and infer the correct
-  types from the `when` call.
-* Completely remove the mirrors implementation of Mockito (`mirrors.dart`).
 
 ## 2.2.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 3.0.0-dev
+version: 3.0.0-alpha+3
 authors:
   - Dmitriy Fibulwinter <fibulwinter@gmail.com>
   - Dart Team <misc@dartlang.org>


### PR DESCRIPTION
This release allows projects to conform to the same type standards as internal code.

The most common way this restricts users of mockito is the following:

```dart
class MockFile extends Mock implements File {}

var f = new MockFile();
// Old: bad code returns a String where a Future<String> is expected.
when(f.readAsString()).thenReturn('text'));

// But no runtime errors are thrown because the return value is merely awaited.
var text = await f.readAsString();

// New: good code answers with an async closure that returns a String.
when(f.readAsString()).thenAnswer((_) async => 'text');
```