### PR TITLE
Bump 3.0.0-alpha to 3.0.0-alpha+4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.0.0-beta+1.0
+## 3.0.0-alpha+4
 
 * Introduce a backward-and-forward compatible API to help users migrate to
   Mockito 3. See more details in the [upgrading-to-mockito-3] doc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.0.0-beta+1.0
+
+* Introduce a backward-and-forward compatible API to help users migrate to
+  Mockito 3. See more details in the [upgrading-to-mockito-3] doc.
+
+[upgrading-to-mockito-3]: https://github.com/dart-lang/mockito/blob/master/upgrading-to-mockito-3.md
+
 ## 3.0.0-alpha+3
 
 * `thenReturn` and `thenAnswer` now support generics and infer the correct

--- a/lib/mockito.dart
+++ b/lib/mockito.dart
@@ -28,6 +28,10 @@ export 'src/mock.dart'
         Expectation,
         PostExpectation,
 
+        // -- Mockito 3.0 compatibility
+        anyNamed,
+        captureAnyNamed,
+
         // -- verification
         verify,
         verifyInOrder,

--- a/lib/mockito.dart
+++ b/lib/mockito.dart
@@ -31,6 +31,8 @@ export 'src/mock.dart'
         // -- Mockito 3.0 compatibility
         anyNamed,
         captureAnyNamed,
+        typedArgThat,
+        typedCaptureThat,
 
         // -- verification
         verify,

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -568,11 +568,13 @@ class ArgMatcher {
 /*ArgMatcher*/ get captureAny => new ArgMatcher(anything, true);
 
 /// An argument matcher that matches an argument that matches [matcher].
-/*ArgMatcher*/ argThat(Matcher matcher) => new ArgMatcher(matcher, false);
+/*ArgMatcher*/ argThat(Matcher matcher, {String named}) =>
+    new ArgMatcher(matcher, false);
 
 /// An argument matcher that matches an argument that matches [matcher], and
 /// captures the argument for later access with `captured`.
-/*ArgMatcher*/ captureThat(Matcher matcher) => new ArgMatcher(matcher, true);
+/*ArgMatcher*/ captureThat(Matcher matcher, {String named}) =>
+    new ArgMatcher(matcher, true);
 
 /// A Strong-mode safe argument matcher that wraps other argument matchers.
 /// See the README for a full explanation.
@@ -584,6 +586,27 @@ T typed<T>(ArgMatcher matcher, {String named}) {
   }
   return null;
 }
+
+/// A forward-compatible argument matcher that matches any argument passed into
+/// the [named] named parameter.
+///
+/// This API will continue to be available in Mockito 3, using the Mockito 3
+/// mechanics. It is offered here so that users may migrate code like
+/// `when(obj.fn(foo: any))` to the Mockito 3 API,
+/// `when(obj.fn(foo: anyNamed('foo')))`, before actually bumping their
+/// dependency on Mockito.
+anyNamed(String named) => typed(any, named: named);
+
+/// A forward-compatible argument matcher that matches any argument passed into
+/// the [named] named parameter, and captures the argument for later access with
+/// `captured`.
+///
+/// This API will continue to be available in Mockito 3, using the Mockito 3.0
+/// mechanics. It is offered here so that users may migrate code like
+/// `when(obj.fn(foo: captureAny))` to the Mockito 3 API,
+/// `when(obj.fn(foo: captureAnyNamed('foo')))`, before actually bumping their
+/// dependency on Mockito.
+captureAnyNamed(String named) => typed(captureAny, named: named);
 
 class VerificationResult {
   List captured = [];

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -608,6 +608,18 @@ anyNamed(String named) => typed(any, named: named);
 /// dependency on Mockito.
 captureAnyNamed(String named) => typed(captureAny, named: named);
 
+/// A forward-compatible argument matcher that matches an argument that matches
+/// [matcher], either as a positional argument or as a named argument, named
+/// [named].
+typedArgThat(Matcher matcher, {String named}) =>
+    typed(argThat(matcher), named: named);
+
+/// A forward-compatible argument matcher that matches an argument that matches
+/// [matcher], either as a positional argument or as a named argument, named
+/// [named], and captures the argument for later access with `captured`.
+typedCaptureThat(Matcher matcher, {String named}) =>
+    typed(captureThat(matcher), named: named);
+
 class VerificationResult {
   List captured = [];
   int callCount;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 3.0.0-beta+1.0
+version: 3.0.0-alpha+4
 authors:
   - Dmitriy Fibulwinter <fibulwinter@gmail.com>
   - Dart Team <misc@dartlang.org>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 3.0.0-alpha+3
+version: 3.0.0-beta+1.0
 authors:
   - Dmitriy Fibulwinter <fibulwinter@gmail.com>
   - Dart Team <misc@dartlang.org>

--- a/test/mockito_test.dart
+++ b/test/mockito_test.dart
@@ -1081,7 +1081,7 @@ void main() {
     });
   });
 
-  group('the intermediate API', () {
+  group("the intermediate API", () {
     test("should mock method with multiple named args and matchers", () {
       when(mock.methodWithTwoNamedArgs(typed(any), y: anyNamed('y')))
           .thenReturn("x y");
@@ -1095,6 +1095,38 @@ void main() {
               y: anyNamed('y'), z: anyNamed('z')))
           .thenReturn("x y z");
       expect(mock.methodWithTwoNamedArgs(42, y: 18, z: 17), equals("x y z"));
+    });
+
+    test("should capture multiple named args", () {
+      mock.methodWithTwoNamedArgs(42, y: 18);
+      mock.methodWithTwoNamedArgs(42, z: 17);
+      var verifiedY = verify(
+          mock.methodWithTwoNamedArgs(typed(any), y: captureAnyNamed('y')));
+      expect(verifiedY.captured.single, equals(18));
+      var verifiedZ = verify(
+          mock.methodWithTwoNamedArgs(typed(any), z: captureAnyNamed('z')));
+      expect(verifiedZ.captured.single, equals(17));
+    });
+
+    test("should mock method with named, typed arg matcher and an arg matcher",
+        () {
+      when(mock.typeParameterizedNamedFn(typed(any), [43],
+              y: typed(any, named: "y"),
+              z: typedArgThat(contains(45), named: 'z')))
+          .thenReturn("A lot!");
+      expect(mock.typeParameterizedNamedFn([42], [43], y: [44], z: [45]),
+          equals("A lot!"));
+    });
+
+    test("should capture multiple named args", () {
+      mock.methodWithTwoNamedArgs(42, y: 18);
+      mock.methodWithTwoNamedArgs(42, z: 17);
+      var verifiedY = verify(mock.methodWithTwoNamedArgs(typed(any),
+          y: typedCaptureThat(lessThan(75), named: 'y')));
+      expect(verifiedY.captured.single, equals(18));
+      var verifiedZ = verify(mock.methodWithTwoNamedArgs(typed(any),
+          z: typedCaptureThat(lessThan(75), named: 'z')));
+      expect(verifiedZ.captured.single, equals(17));
     });
   });
 }

--- a/test/mockito_test.dart
+++ b/test/mockito_test.dart
@@ -1080,4 +1080,21 @@ void main() {
       expect(() => mock.methodWithoutArgs(), returnsNormally);
     });
   });
+
+  group('the intermediate API', () {
+    test("should mock method with multiple named args and matchers", () {
+      when(mock.methodWithTwoNamedArgs(typed(any), y: anyNamed('y')))
+          .thenReturn("x y");
+      when(mock.methodWithTwoNamedArgs(typed(any), z: anyNamed('z')))
+          .thenReturn("x z");
+      expect(mock.methodWithTwoNamedArgs(42), isNull);
+      expect(mock.methodWithTwoNamedArgs(42, y: 18), equals("x y"));
+      expect(mock.methodWithTwoNamedArgs(42, z: 17), equals("x z"));
+      expect(mock.methodWithTwoNamedArgs(42, y: 18, z: 17), isNull);
+      when(mock.methodWithTwoNamedArgs(typed(any),
+              y: anyNamed('y'), z: anyNamed('z')))
+          .thenReturn("x y z");
+      expect(mock.methodWithTwoNamedArgs(42, y: 18, z: 17), equals("x y z"));
+    });
+  });
 }


### PR DESCRIPTION
This is the backward-and-forward-compatibility release of Mockito, as laid out in [upgrading-to-mockito-3](https://github.com/dart-lang/mockito/blob/master/upgrading-to-mockito-3.md).

It just introduces a few pieces of API that will help code to migrate. See the doc for more info.