### PR TITLE
Better verification error

### DIFF
--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -565,6 +565,9 @@ class _VerifyCall {
       inv.verified = true;
     });
   }
+
+  String toString() =>
+      'VerifyCall<mock: $mock, memberName: ${verifyInvocation.memberName}>';
 }
 
 class ArgMatcher {
@@ -673,7 +676,16 @@ Verification get verify => _makeVerify(false);
 
 Verification _makeVerify(bool never) {
   if (_verifyCalls.isNotEmpty) {
-    throw new StateError(_verifyCalls.join());
+    var message = 'Verification appears to be in progress.';
+    if (_verifyCalls.length == 1) {
+      message =
+          '$message One verify call has been stored: ${_verifyCalls.single}';
+    } else {
+      message =
+          '$message ${_verifyCalls.length} verify calls have been stored. '
+          '[${_verifyCalls.first}, ..., ${_verifyCalls.last}]';
+    }
+    throw new StateError(message);
   }
   _verificationInProgress = true;
   return <T>(T mock) {

--- a/test/mockito_test.dart
+++ b/test/mockito_test.dart
@@ -705,6 +705,29 @@ void main() {
       });
       verify(mock.setter = "A");
     });
+
+    test("should throw meaningful errors when verification is interrupted", () {
+      var badHelper = () => throw 'boo';
+      try {
+        verify(mock.methodWithNamedArgs(42, y: badHelper()));
+        fail("veriy call was expected to throw!");
+      } catch (_) {}
+      // At this point, verification was interrupted, so
+      // `_verificationInProgress` is still `true`. Calling mock methods below
+      // adds items to `_verifyCalls`.
+      mock.methodWithNamedArgs(42, y: 17);
+      mock.methodWithNamedArgs(42, y: 17);
+      try {
+        verify(mock.methodWithNamedArgs(42, y: 17));
+        fail("veriy call was expected to throw!");
+      } catch (e) {
+        expect(e, new isInstanceOf<StateError>());
+        expect(
+            e.message,
+            contains(
+                'Verification appears to be in progress. 2 verify calls have been stored.'));
+      }
+    });
   });
 
   group("verify() qualifies", () {


### PR DESCRIPTION
While upgrading mockito tests, I kept hitting this super annoying situation, where a verification error just printed `_Instance of VerifyCall_Instance of VerifyCall_Instance...`.