### PR TITLE
Move all tests of deprecated typed APIs to test/deprecated_apis

### DIFF
--- a/lib/mockito.dart
+++ b/lib/mockito.dart
@@ -39,9 +39,9 @@ export 'src/mock.dart'
         Verification,
 
         // -- deprecated
-        typed,
-        typedArgThat,
-        typedCaptureThat,
+        typed, // ignore: deprecated_member_use
+        typedArgThat, // ignore: deprecated_member_use
+        typedCaptureThat, // ignore: deprecated_member_use
 
         // -- misc
         throwOnMissingStub,

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -593,6 +593,7 @@ class _VerifyCall {
     });
   }
 
+  @override
   String toString() =>
       'VerifyCall<mock: $mock, memberName: ${verifyInvocation.memberName}>';
 }

--- a/test/deprecated_apis/capture_test.dart
+++ b/test/deprecated_apis/capture_test.dart
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@deprecated
+library mockito.test.deprecated_apis.capture_test;
+
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
-import 'utils.dart';
+import '../utils.dart';
 
 class _RealClass {
   _RealClass innerObj;
@@ -27,15 +30,15 @@ class _RealClass {
   }
 }
 
-class _MockedClass extends Mock implements _RealClass {}
+class MockedClass extends Mock implements _RealClass {}
 
 void main() {
-  _MockedClass mock;
+  MockedClass mock;
 
   var isNsmForwarding = assessNsmForwarding();
 
   setUp(() {
-    mock = new _MockedClass();
+    mock = new MockedClass();
   });
 
   tearDown(() {
@@ -47,7 +50,8 @@ void main() {
   group('capture', () {
     test('captureAny should match anything', () {
       mock.methodWithNormalArgs(42);
-      expect(verify(mock.methodWithNormalArgs(captureAny)).captured.single,
+      expect(
+          verify(mock.methodWithNormalArgs(typed(captureAny))).captured.single,
           equals(42));
     });
 
@@ -57,20 +61,22 @@ void main() {
       mock.methodWithNormalArgs(43);
       mock.methodWithNormalArgs(45);
       expect(
-          verify(mock.methodWithNormalArgs(captureThat(lessThan(44)))).captured,
+          verify(mock.methodWithNormalArgs(typed(captureThat(lessThan(44)))))
+              .captured,
           equals([42, 43]));
     });
 
     test('should capture list arguments', () {
       mock.methodWithListArgs([42]);
-      expect(verify(mock.methodWithListArgs(captureAny)).captured.single,
+      expect(verify(mock.methodWithListArgs(typed(captureAny))).captured.single,
           equals([42]));
     });
 
     test('should capture multiple arguments', () {
       mock.methodWithPositionalArgs(1, 2);
       expect(
-          verify(mock.methodWithPositionalArgs(captureAny, captureAny))
+          verify(mock.methodWithPositionalArgs(
+                  typed(captureAny), typed(captureAny)))
               .captured,
           equals([1, 2]));
     });
@@ -80,7 +86,8 @@ void main() {
       mock.methodWithPositionalArgs(2, 3);
       var expectedCaptures = isNsmForwarding ? [1, null, 2, 3] : [2, 3];
       expect(
-          verify(mock.methodWithPositionalArgs(captureAny, captureAny))
+          verify(mock.methodWithPositionalArgs(
+                  typed(captureAny), typed(captureAny)))
               .captured,
           equals(expectedCaptures));
     });
@@ -88,7 +95,7 @@ void main() {
     test('should capture multiple invocations', () {
       mock.methodWithNormalArgs(1);
       mock.methodWithNormalArgs(2);
-      expect(verify(mock.methodWithNormalArgs(captureAny)).captured,
+      expect(verify(mock.methodWithNormalArgs(typed(captureAny))).captured,
           equals([1, 2]));
     });
   });

--- a/test/deprecated_apis/mockito_test.dart
+++ b/test/deprecated_apis/mockito_test.dart
@@ -1,0 +1,137 @@
+// Copyright 2016 Dart Mockito authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@deprecated
+library mockito.test.deprecated_apis.mockito_test;
+
+import 'dart:async';
+
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+class _RealClass {
+  _RealClass innerObj;
+  String methodWithoutArgs() => "Real";
+  String methodWithNormalArgs(int x) => "Real";
+  String methodWithListArgs(List<int> x) => "Real";
+  String methodWithPositionalArgs(int x, [int y]) => "Real";
+  String methodWithNamedArgs(int x, {int y}) => "Real";
+  String methodWithTwoNamedArgs(int x, {int y, int z}) => "Real";
+  String methodWithObjArgs(_RealClass x) => "Real";
+  Future<String> methodReturningFuture() => new Future.value("Real");
+  Stream<String> methodReturningStream() => new Stream.fromIterable(["Real"]);
+  String get getter => "Real";
+  set setter(String arg) {
+    throw new StateError("I must be mocked");
+  }
+}
+
+abstract class Foo {
+  String bar();
+}
+
+abstract class AbstractFoo implements Foo {
+  @override
+  String bar() => baz();
+
+  String baz();
+}
+
+class MockFoo extends AbstractFoo with Mock {}
+
+class _MockedClass extends Mock implements _RealClass {}
+
+expectFail(String expectedMessage, expectedToFail()) {
+  try {
+    expectedToFail();
+    fail("It was expected to fail!");
+  } catch (e) {
+    if (!(e is TestFailure)) {
+      throw e;
+    } else {
+      if (expectedMessage != e.message) {
+        throw new TestFailure("Failed, but with wrong message: ${e.message}");
+      }
+    }
+  }
+}
+
+String noMatchingCallsFooter = "(If you called `verify(...).called(0);`, "
+    "please instead use `verifyNever(...);`.)";
+
+void main() {
+  _MockedClass mock;
+
+  setUp(() {
+    mock = new _MockedClass();
+  });
+
+  tearDown(() {
+    // In some of the tests that expect an Error to be thrown, Mockito's
+    // global state can become invalid. Reset it.
+    resetMockitoState();
+  });
+
+  group("when()", () {
+    test("should mock method with argument matcher", () {
+      when(mock.methodWithNormalArgs(typed(argThat(greaterThan(100)))))
+          .thenReturn("A lot!");
+      expect(mock.methodWithNormalArgs(100), isNull);
+      expect(mock.methodWithNormalArgs(101), equals("A lot!"));
+    });
+
+    test("should mock method with any argument matcher", () {
+      when(mock.methodWithNormalArgs(typed(any))).thenReturn("A lot!");
+      expect(mock.methodWithNormalArgs(100), equals("A lot!"));
+      expect(mock.methodWithNormalArgs(101), equals("A lot!"));
+    });
+
+    test("should mock method with any list argument matcher", () {
+      when(mock.methodWithListArgs(typed(any))).thenReturn("A lot!");
+      expect(mock.methodWithListArgs([42]), equals("A lot!"));
+      expect(mock.methodWithListArgs([43]), equals("A lot!"));
+    });
+
+    test("should mock method with mix of argument matchers and real things",
+        () {
+      when(mock.methodWithPositionalArgs(typed(argThat(greaterThan(100))), 17))
+          .thenReturn("A lot with 17");
+      expect(mock.methodWithPositionalArgs(100, 17), isNull);
+      expect(mock.methodWithPositionalArgs(101, 18), isNull);
+      expect(mock.methodWithPositionalArgs(101, 17), equals("A lot with 17"));
+    });
+
+    //no need to mock setter, except if we will have spies later...
+    test("should mock method with thrown result", () {
+      when(mock.methodWithNormalArgs(typed(any)))
+          .thenThrow(new StateError('Boo'));
+      expect(() => mock.methodWithNormalArgs(42), throwsStateError);
+    });
+
+    test("should mock method with calculated result", () {
+      when(mock.methodWithNormalArgs(typed(any))).thenAnswer(
+          (Invocation inv) => inv.positionalArguments[0].toString());
+      expect(mock.methodWithNormalArgs(43), equals("43"));
+      expect(mock.methodWithNormalArgs(42), equals("42"));
+    });
+
+    test("should mock method with calculated result", () {
+      when(mock.methodWithNormalArgs(typed(argThat(equals(43)))))
+          .thenReturn("43");
+      when(mock.methodWithNormalArgs(typed(argThat(equals(42)))))
+          .thenReturn("42");
+      expect(mock.methodWithNormalArgs(43), equals("43"));
+    });
+  });
+}

--- a/test/deprecated_apis/until_called_test.dart
+++ b/test/deprecated_apis/until_called_test.dart
@@ -1,0 +1,200 @@
+// Copyright 2016 Dart Mockito authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@deprecated
+library mockito.test.deprecated_apis.until_called_test;
+
+import 'dart:async';
+
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+class _RealClass {
+  _RealClass innerObj;
+  String methodWithoutArgs() => 'Real';
+  String methodWithNormalArgs(int x) => 'Real';
+  String methodWithListArgs(List<int> x) => 'Real';
+  String methodWithPositionalArgs(int x, [int y]) => 'Real';
+  String methodWithNamedArgs(int x, {int y}) => 'Real';
+  String methodWithTwoNamedArgs(int x, {int y, int z}) => 'Real';
+  String methodWithObjArgs(_RealClass x) => 'Real';
+  String typeParameterizedFn(List<int> w, List<int> x,
+          [List<int> y, List<int> z]) =>
+      'Real';
+  String typeParameterizedNamedFn(List<int> w, List<int> x,
+          {List<int> y, List<int> z}) =>
+      'Real';
+  String get getter => 'Real';
+  set setter(String arg) {
+    throw new StateError('I must be mocked');
+  }
+}
+
+class CallMethodsEvent {}
+
+/// Listens on a stream and upon any event calls all methods in [_RealClass].
+class _RealClassController {
+  final _RealClass _realClass;
+
+  _RealClassController(
+      this._realClass, StreamController<CallMethodsEvent> streamController) {
+    streamController.stream.listen(_callAllMethods);
+  }
+
+  Future<Null> _callAllMethods(_) async {
+    _realClass
+      ..methodWithoutArgs()
+      ..methodWithNormalArgs(1)
+      ..methodWithListArgs([1, 2])
+      ..methodWithPositionalArgs(1, 2)
+      ..methodWithNamedArgs(1, y: 2)
+      ..methodWithTwoNamedArgs(1, y: 2, z: 3)
+      ..methodWithObjArgs(new _RealClass())
+      ..typeParameterizedFn([1, 2], [3, 4], [5, 6], [7, 8])
+      ..typeParameterizedNamedFn([1, 2], [3, 4], y: [5, 6], z: [7, 8])
+      ..getter
+      ..setter = 'A';
+  }
+}
+
+class MockedClass extends Mock implements _RealClass {}
+
+void main() {
+  MockedClass mock;
+
+  setUp(() {
+    mock = new MockedClass();
+  });
+
+  tearDown(() {
+    // In some of the tests that expect an Error to be thrown, Mockito's
+    // global state can become invalid. Reset it.
+    resetMockitoState();
+  });
+
+  group('untilCalled', () {
+    StreamController<CallMethodsEvent> streamController =
+        new StreamController.broadcast();
+
+    group('on methods already called', () {
+      test('waits for method with normal args', () async {
+        mock.methodWithNormalArgs(1);
+
+        await untilCalled(mock.methodWithNormalArgs(typed(any)));
+
+        verify(mock.methodWithNormalArgs(typed(any))).called(1);
+      });
+
+      test('waits for method with list args', () async {
+        mock.methodWithListArgs([1]);
+
+        await untilCalled(mock.methodWithListArgs(typed(any)));
+
+        verify(mock.methodWithListArgs(typed(any))).called(1);
+      });
+
+      test('waits for method with positional args', () async {
+        mock.methodWithPositionalArgs(1, 2);
+
+        await untilCalled(
+            mock.methodWithPositionalArgs(typed(any), typed(any)));
+
+        verify(mock.methodWithPositionalArgs(typed(any), typed(any))).called(1);
+      });
+
+      test('waits for method with named args', () async {
+        mock.methodWithNamedArgs(1, y: 2);
+
+        await untilCalled(mock.methodWithNamedArgs(any, y: anyNamed('y')));
+
+        verify(mock.methodWithNamedArgs(any, y: anyNamed('y'))).called(1);
+      });
+
+      test('waits for method with obj args', () async {
+        mock.methodWithObjArgs(new _RealClass());
+
+        await untilCalled(mock.methodWithObjArgs(typed(any)));
+
+        verify(mock.methodWithObjArgs(typed(any))).called(1);
+      });
+
+      test('waits for function with positional parameters', () async {
+        mock.typeParameterizedFn([1, 2], [3, 4], [5, 6], [7, 8]);
+
+        await untilCalled(mock.typeParameterizedFn(
+            typed(any), typed(any), typed(any), typed(any)));
+
+        verify(mock.typeParameterizedFn(
+                typed(any), typed(any), typed(any), typed(any)))
+            .called(1);
+      });
+    });
+
+    group('on methods not yet called', () {
+      setUp(() {
+        new _RealClassController(mock, streamController);
+      });
+
+      test('waits for method with normal args', () async {
+        streamController.add(new CallMethodsEvent());
+        verifyNever(mock.methodWithNormalArgs(typed(any)));
+
+        await untilCalled(mock.methodWithNormalArgs(typed(any)));
+
+        verify(mock.methodWithNormalArgs(typed(any))).called(1);
+      });
+
+      test('waits for method with list args', () async {
+        streamController.add(new CallMethodsEvent());
+        verifyNever(mock.methodWithListArgs(typed(any)));
+
+        await untilCalled(mock.methodWithListArgs(typed(any)));
+
+        verify(mock.methodWithListArgs(typed(any))).called(1);
+      });
+
+      test('waits for method with positional args', () async {
+        streamController.add(new CallMethodsEvent());
+        verifyNever(mock.methodWithPositionalArgs(typed(any), typed(any)));
+
+        await untilCalled(
+            mock.methodWithPositionalArgs(typed(any), typed(any)));
+
+        verify(mock.methodWithPositionalArgs(typed(any), typed(any))).called(1);
+      });
+
+      test('waits for method with obj args', () async {
+        streamController.add(new CallMethodsEvent());
+        verifyNever(mock.methodWithObjArgs(typed(any)));
+
+        await untilCalled(mock.methodWithObjArgs(typed(any)));
+
+        verify(mock.methodWithObjArgs(typed(any))).called(1);
+      });
+
+      test('waits for function with positional parameters', () async {
+        streamController.add(new CallMethodsEvent());
+        verifyNever(mock.typeParameterizedFn(
+            typed(any), typed(any), typed(any), typed(any)));
+
+        await untilCalled(mock.typeParameterizedFn(
+            typed(any), typed(any), typed(any), typed(any)));
+
+        verify(mock.typeParameterizedFn(
+                typed(any), typed(any), typed(any), typed(any)))
+            .called(1);
+      });
+    });
+  });
+}

--- a/test/deprecated_apis/verify_test.dart
+++ b/test/deprecated_apis/verify_test.dart
@@ -1,0 +1,123 @@
+// Copyright 2018 Dart Mockito authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@deprecated
+library mockito.test.deprecated_apis.verify_test;
+
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+class _RealClass {
+  _RealClass innerObj;
+  String methodWithoutArgs() => 'Real';
+  String methodWithNormalArgs(int x) => 'Real';
+  String methodWithListArgs(List<int> x) => 'Real';
+  String methodWithOptionalArg([int x]) => 'Real';
+  String methodWithPositionalArgs(int x, [int y]) => 'Real';
+  String methodWithNamedArgs(int x, {int y}) => 'Real';
+  String methodWithOnlyNamedArgs({int y, int z}) => 'Real';
+  String methodWithObjArgs(_RealClass x) => 'Real';
+  String get getter => 'Real';
+  set setter(String arg) {
+    throw new StateError('I must be mocked');
+  }
+
+  String methodWithLongArgs(LongToString a, LongToString b,
+          {LongToString c, LongToString d}) =>
+      'Real';
+}
+
+class LongToString {
+  final List aList;
+  final Map aMap;
+  final String aString;
+
+  LongToString(this.aList, this.aMap, this.aString);
+
+  @override
+  String toString() => 'LongToString<\n'
+      '    aList: $aList\n'
+      '    aMap: $aMap\n'
+      '    aString: $aString\n'
+      '>';
+}
+
+class _MockedClass extends Mock implements _RealClass {}
+
+expectFail(String expectedMessage, expectedToFail()) {
+  try {
+    expectedToFail();
+    fail('It was expected to fail!');
+  } catch (e) {
+    if (!(e is TestFailure)) {
+      throw e;
+    } else {
+      if (expectedMessage != e.message) {
+        throw new TestFailure('Failed, but with wrong message: ${e.message}');
+      }
+    }
+  }
+}
+
+String noMatchingCallsFooter = '(If you called `verify(...).called(0);`, '
+    'please instead use `verifyNever(...);`.)';
+
+void main() {
+  _MockedClass mock;
+
+  setUp(() {
+    mock = new _MockedClass();
+  });
+
+  tearDown(() {
+    // In some of the tests that expect an Error to be thrown, Mockito's
+    // global state can become invalid. Reset it.
+    resetMockitoState();
+  });
+
+  group('verify', () {
+    test('should mock method with argument matcher', () {
+      mock.methodWithNormalArgs(100);
+      expectFail(
+          'No matching calls. All calls: '
+          '_MockedClass.methodWithNormalArgs(100)\n'
+          '$noMatchingCallsFooter', () {
+        verify(mock.methodWithNormalArgs(typed(argThat(greaterThan(100)))));
+      });
+      verify(
+          mock.methodWithNormalArgs(typed(argThat(greaterThanOrEqualTo(100)))));
+    });
+
+    test('should mock method with mix of argument matchers and real things',
+        () {
+      mock.methodWithPositionalArgs(100, 17);
+      expectFail(
+          'No matching calls. All calls: '
+          '_MockedClass.methodWithPositionalArgs(100, 17)\n'
+          '$noMatchingCallsFooter', () {
+        verify(mock.methodWithPositionalArgs(
+            typed(argThat(greaterThanOrEqualTo(100))), 18));
+      });
+      expectFail(
+          'No matching calls. All calls: '
+          '_MockedClass.methodWithPositionalArgs(100, 17)\n'
+          '$noMatchingCallsFooter', () {
+        verify(mock.methodWithPositionalArgs(
+            typed(argThat(greaterThan(100))), 17));
+      });
+      verify(mock.methodWithPositionalArgs(
+          typed(argThat(greaterThanOrEqualTo(100))), 17));
+    });
+  });
+}

--- a/test/mockito_test.dart
+++ b/test/mockito_test.dart
@@ -19,15 +19,15 @@ import 'package:test/test.dart';
 
 import 'utils.dart';
 
-class RealClass {
-  RealClass innerObj;
+class _RealClass {
+  _RealClass innerObj;
   String methodWithoutArgs() => "Real";
   String methodWithNormalArgs(int x) => "Real";
   String methodWithListArgs(List<int> x) => "Real";
   String methodWithPositionalArgs(int x, [int y]) => "Real";
   String methodWithNamedArgs(int x, {int y}) => "Real";
   String methodWithTwoNamedArgs(int x, {int y, int z}) => "Real";
-  String methodWithObjArgs(RealClass x) => "Real";
+  String methodWithObjArgs(_RealClass x) => "Real";
   Future<String> methodReturningFuture() => new Future.value("Real");
   Stream<String> methodReturningStream() => new Stream.fromIterable(["Real"]);
   String get getter => "Real";
@@ -36,20 +36,20 @@ class RealClass {
   }
 }
 
-abstract class Foo {
+abstract class _Foo {
   String bar();
 }
 
-abstract class AbstractFoo implements Foo {
+abstract class _AbstractFoo implements _Foo {
   @override
   String bar() => baz();
 
   String baz();
 }
 
-class MockFoo extends AbstractFoo with Mock {}
+class _MockFoo extends _AbstractFoo with Mock {}
 
-class MockedClass extends Mock implements RealClass {}
+class _MockedClass extends Mock implements _RealClass {}
 
 expectFail(String expectedMessage, expectedToFail()) {
   try {
@@ -70,12 +70,12 @@ String noMatchingCallsFooter = "(If you called `verify(...).called(0);`, "
     "please instead use `verifyNever(...);`.)";
 
 void main() {
-  MockedClass mock;
+  _MockedClass mock;
 
   var isNsmForwarding = assessNsmForwarding();
 
   setUp(() {
-    mock = new MockedClass();
+    mock = new _MockedClass();
   });
 
   tearDown(() {
@@ -86,7 +86,7 @@ void main() {
 
   group("mixin support", () {
     test("should work", () {
-      var foo = new MockFoo();
+      var foo = new _MockFoo();
       when(foo.baz()).thenReturn('baz');
       expect(foo.bar(), 'baz');
     });
@@ -105,9 +105,9 @@ void main() {
     });
 
     test("should mock method with mock args", () {
-      var m1 = new MockedClass();
+      var m1 = new _MockedClass();
       when(mock.methodWithObjArgs(m1)).thenReturn("Ultimate Answer");
-      expect(mock.methodWithObjArgs(new MockedClass()), isNull);
+      expect(mock.methodWithObjArgs(new _MockedClass()), isNull);
       expect(mock.methodWithObjArgs(m1), equals("Ultimate Answer"));
     });
 
@@ -132,20 +132,20 @@ void main() {
     });
 
     test("should mock method with argument matcher", () {
-      when(mock.methodWithNormalArgs(typed(argThat(greaterThan(100)))))
+      when(mock.methodWithNormalArgs(argThat(greaterThan(100))))
           .thenReturn("A lot!");
       expect(mock.methodWithNormalArgs(100), isNull);
       expect(mock.methodWithNormalArgs(101), equals("A lot!"));
     });
 
     test("should mock method with any argument matcher", () {
-      when(mock.methodWithNormalArgs(typed(any))).thenReturn("A lot!");
+      when(mock.methodWithNormalArgs(any)).thenReturn("A lot!");
       expect(mock.methodWithNormalArgs(100), equals("A lot!"));
       expect(mock.methodWithNormalArgs(101), equals("A lot!"));
     });
 
     test("should mock method with any list argument matcher", () {
-      when(mock.methodWithListArgs(typed(any))).thenReturn("A lot!");
+      when(mock.methodWithListArgs(any)).thenReturn("A lot!");
       expect(mock.methodWithListArgs([42]), equals("A lot!"));
       expect(mock.methodWithListArgs([43]), equals("A lot!"));
     });
@@ -169,7 +169,7 @@ void main() {
 
     test("should mock method with mix of argument matchers and real things",
         () {
-      when(mock.methodWithPositionalArgs(typed(argThat(greaterThan(100))), 17))
+      when(mock.methodWithPositionalArgs(argThat(greaterThan(100)), 17))
           .thenReturn("A lot with 17");
       expect(mock.methodWithPositionalArgs(100, 17), isNull);
       expect(mock.methodWithPositionalArgs(101, 18), isNull);
@@ -191,7 +191,7 @@ void main() {
     });
 
     test("should have default toString when it is not mocked", () {
-      expect(mock.toString(), equals("MockedClass"));
+      expect(mock.toString(), equals("_MockedClass"));
     });
 
     test("should have toString as name when it is not mocked", () {
@@ -200,33 +200,32 @@ void main() {
     });
 
     test("should mock equals between mocks when givenHashCode is equals", () {
-      var anotherMock = named(new MockedClass(), hashCode: 42);
+      var anotherMock = named(new _MockedClass(), hashCode: 42);
       named(mock, hashCode: 42);
       expect(mock == anotherMock, isTrue);
     });
 
     test("should use identical equality between it is not mocked", () {
-      var anotherMock = new MockedClass();
+      var anotherMock = new _MockedClass();
       expect(mock == anotherMock, isFalse);
       expect(mock == mock, isTrue);
     });
 
     //no need to mock setter, except if we will have spies later...
     test("should mock method with thrown result", () {
-      when(mock.methodWithNormalArgs(typed(any)))
-          .thenThrow(new StateError('Boo'));
+      when(mock.methodWithNormalArgs(any)).thenThrow(new StateError('Boo'));
       expect(() => mock.methodWithNormalArgs(42), throwsStateError);
     });
 
     test("should mock method with calculated result", () {
-      when(mock.methodWithNormalArgs(typed(any))).thenAnswer(
+      when(mock.methodWithNormalArgs(any)).thenAnswer(
           (Invocation inv) => inv.positionalArguments[0].toString());
       expect(mock.methodWithNormalArgs(43), equals("43"));
       expect(mock.methodWithNormalArgs(42), equals("42"));
     });
 
     test("should return mock to make simple oneline mocks", () {
-      RealClass mockWithSetup = new MockedClass();
+      _RealClass mockWithSetup = new _MockedClass();
       when(mockWithSetup.methodWithoutArgs()).thenReturn("oneline");
       expect(mockWithSetup.methodWithoutArgs(), equals("oneline"));
     });
@@ -238,10 +237,8 @@ void main() {
     });
 
     test("should mock method with calculated result", () {
-      when(mock.methodWithNormalArgs(typed(argThat(equals(43)))))
-          .thenReturn("43");
-      when(mock.methodWithNormalArgs(typed(argThat(equals(42)))))
-          .thenReturn("42");
+      when(mock.methodWithNormalArgs(argThat(equals(43)))).thenReturn("43");
+      when(mock.methodWithNormalArgs(argThat(equals(42)))).thenReturn("42");
       expect(mock.methodWithNormalArgs(43), equals("43"));
     });
 
@@ -249,7 +246,7 @@ void main() {
     test("should throw if `when` is called while stubbing", () {
       expect(() {
         var responseHelper = () {
-          var mock2 = new MockedClass();
+          var mock2 = new _MockedClass();
           when(mock2.getter).thenReturn("A");
           return mock2;
         };

--- a/test/until_called_test.dart
+++ b/test/until_called_test.dart
@@ -17,15 +17,15 @@ import 'dart:async';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
-class RealClass {
-  RealClass innerObj;
+class _RealClass {
+  _RealClass innerObj;
   String methodWithoutArgs() => 'Real';
   String methodWithNormalArgs(int x) => 'Real';
   String methodWithListArgs(List<int> x) => 'Real';
   String methodWithPositionalArgs(int x, [int y]) => 'Real';
   String methodWithNamedArgs(int x, {int y}) => 'Real';
   String methodWithTwoNamedArgs(int x, {int y, int z}) => 'Real';
-  String methodWithObjArgs(RealClass x) => 'Real';
+  String methodWithObjArgs(_RealClass x) => 'Real';
   String typeParameterizedFn(List<int> w, List<int> x,
           [List<int> y, List<int> z]) =>
       'Real';
@@ -40,11 +40,11 @@ class RealClass {
 
 class CallMethodsEvent {}
 
-/// Listens on a stream and upon any event calls all methods in [RealClass].
-class RealClassController {
-  final RealClass _realClass;
+/// Listens on a stream and upon any event calls all methods in [_RealClass].
+class _RealClassController {
+  final _RealClass _realClass;
 
-  RealClassController(
+  _RealClassController(
       this._realClass, StreamController<CallMethodsEvent> streamController) {
     streamController.stream.listen(_callAllMethods);
   }
@@ -57,7 +57,7 @@ class RealClassController {
       ..methodWithPositionalArgs(1, 2)
       ..methodWithNamedArgs(1, y: 2)
       ..methodWithTwoNamedArgs(1, y: 2, z: 3)
-      ..methodWithObjArgs(new RealClass())
+      ..methodWithObjArgs(new _RealClass())
       ..typeParameterizedFn([1, 2], [3, 4], [5, 6], [7, 8])
       ..typeParameterizedNamedFn([1, 2], [3, 4], y: [5, 6], z: [7, 8])
       ..getter
@@ -65,13 +65,13 @@ class RealClassController {
   }
 }
 
-class MockedClass extends Mock implements RealClass {}
+class _MockedClass extends Mock implements _RealClass {}
 
 void main() {
-  MockedClass mock;
+  _MockedClass mock;
 
   setUp(() {
-    mock = new MockedClass();
+    mock = new _MockedClass();
   });
 
   tearDown(() {
@@ -96,26 +96,25 @@ void main() {
       test('waits for method with normal args', () async {
         mock.methodWithNormalArgs(1);
 
-        await untilCalled(mock.methodWithNormalArgs(typed(any)));
+        await untilCalled(mock.methodWithNormalArgs(any));
 
-        verify(mock.methodWithNormalArgs(typed(any))).called(1);
+        verify(mock.methodWithNormalArgs(any)).called(1);
       });
 
       test('waits for method with list args', () async {
         mock.methodWithListArgs([1]);
 
-        await untilCalled(mock.methodWithListArgs(typed(any)));
+        await untilCalled(mock.methodWithListArgs(any));
 
-        verify(mock.methodWithListArgs(typed(any))).called(1);
+        verify(mock.methodWithListArgs(any)).called(1);
       });
 
       test('waits for method with positional args', () async {
         mock.methodWithPositionalArgs(1, 2);
 
-        await untilCalled(
-            mock.methodWithPositionalArgs(typed(any), typed(any)));
+        await untilCalled(mock.methodWithPositionalArgs(any, any));
 
-        verify(mock.methodWithPositionalArgs(typed(any), typed(any))).called(1);
+        verify(mock.methodWithPositionalArgs(any, any)).called(1);
       });
 
       test('waits for method with named args', () async {
@@ -138,22 +137,19 @@ void main() {
       });
 
       test('waits for method with obj args', () async {
-        mock.methodWithObjArgs(new RealClass());
+        mock.methodWithObjArgs(new _RealClass());
 
-        await untilCalled(mock.methodWithObjArgs(typed(any)));
+        await untilCalled(mock.methodWithObjArgs(any));
 
-        verify(mock.methodWithObjArgs(typed(any))).called(1);
+        verify(mock.methodWithObjArgs(any)).called(1);
       });
 
       test('waits for function with positional parameters', () async {
         mock.typeParameterizedFn([1, 2], [3, 4], [5, 6], [7, 8]);
 
-        await untilCalled(mock.typeParameterizedFn(
-            typed(any), typed(any), typed(any), typed(any)));
+        await untilCalled(mock.typeParameterizedFn(any, any, any, any));
 
-        verify(mock.typeParameterizedFn(
-                typed(any), typed(any), typed(any), typed(any)))
-            .called(1);
+        verify(mock.typeParameterizedFn(any, any, any, any)).called(1);
       });
 
       test('waits for function with named parameters', () async {
@@ -186,7 +182,7 @@ void main() {
 
     group('on methods not yet called', () {
       setUp(() {
-        new RealClassController(mock, streamController);
+        new _RealClassController(mock, streamController);
       });
 
       test('waits for method without args', () async {
@@ -200,30 +196,29 @@ void main() {
 
       test('waits for method with normal args', () async {
         streamController.add(new CallMethodsEvent());
-        verifyNever(mock.methodWithNormalArgs(typed(any)));
+        verifyNever(mock.methodWithNormalArgs(any));
 
-        await untilCalled(mock.methodWithNormalArgs(typed(any)));
+        await untilCalled(mock.methodWithNormalArgs(any));
 
-        verify(mock.methodWithNormalArgs(typed(any))).called(1);
+        verify(mock.methodWithNormalArgs(any)).called(1);
       });
 
       test('waits for method with list args', () async {
         streamController.add(new CallMethodsEvent());
-        verifyNever(mock.methodWithListArgs(typed(any)));
+        verifyNever(mock.methodWithListArgs(any));
 
-        await untilCalled(mock.methodWithListArgs(typed(any)));
+        await untilCalled(mock.methodWithListArgs(any));
 
-        verify(mock.methodWithListArgs(typed(any))).called(1);
+        verify(mock.methodWithListArgs(any)).called(1);
       });
 
       test('waits for method with positional args', () async {
         streamController.add(new CallMethodsEvent());
-        verifyNever(mock.methodWithPositionalArgs(typed(any), typed(any)));
+        verifyNever(mock.methodWithPositionalArgs(any, any));
 
-        await untilCalled(
-            mock.methodWithPositionalArgs(typed(any), typed(any)));
+        await untilCalled(mock.methodWithPositionalArgs(any, any));
 
-        verify(mock.methodWithPositionalArgs(typed(any), typed(any))).called(1);
+        verify(mock.methodWithPositionalArgs(any, any)).called(1);
       });
 
       test('waits for method with named args', () async {
@@ -250,24 +245,20 @@ void main() {
 
       test('waits for method with obj args', () async {
         streamController.add(new CallMethodsEvent());
-        verifyNever(mock.methodWithObjArgs(typed(any)));
+        verifyNever(mock.methodWithObjArgs(any));
 
-        await untilCalled(mock.methodWithObjArgs(typed(any)));
+        await untilCalled(mock.methodWithObjArgs(any));
 
-        verify(mock.methodWithObjArgs(typed(any))).called(1);
+        verify(mock.methodWithObjArgs(any)).called(1);
       });
 
       test('waits for function with positional parameters', () async {
         streamController.add(new CallMethodsEvent());
-        verifyNever(mock.typeParameterizedFn(
-            typed(any), typed(any), typed(any), typed(any)));
+        verifyNever(mock.typeParameterizedFn(any, any, any, any));
 
-        await untilCalled(mock.typeParameterizedFn(
-            typed(any), typed(any), typed(any), typed(any)));
+        await untilCalled(mock.typeParameterizedFn(any, any, any, any));
 
-        verify(mock.typeParameterizedFn(
-                typed(any), typed(any), typed(any), typed(any)))
-            .called(1);
+        verify(mock.typeParameterizedFn(any, any, any, any)).called(1);
       });
 
       test('waits for function with named parameters', () async {

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -10,7 +10,7 @@ bool assessNsmForwarding() {
   var signal = new MockNsmForwardingSignal();
   signal.fn();
   try {
-    verify(signal.fn(typed(any)));
+    verify(signal.fn(any));
     return true;
   } catch (_) {
     // The verify failed, because the default value of 7 was not passed to

--- a/test/verify_test.dart
+++ b/test/verify_test.dart
@@ -17,8 +17,8 @@ import 'package:test/test.dart';
 
 import 'utils.dart';
 
-class RealClass {
-  RealClass innerObj;
+class _RealClass {
+  _RealClass innerObj;
   String methodWithoutArgs() => 'Real';
   String methodWithNormalArgs(int x) => 'Real';
   String methodWithListArgs(List<int> x) => 'Real';
@@ -26,7 +26,7 @@ class RealClass {
   String methodWithPositionalArgs(int x, [int y]) => 'Real';
   String methodWithNamedArgs(int x, {int y}) => 'Real';
   String methodWithOnlyNamedArgs({int y, int z}) => 'Real';
-  String methodWithObjArgs(RealClass x) => 'Real';
+  String methodWithObjArgs(_RealClass x) => 'Real';
   String get getter => 'Real';
   set setter(String arg) {
     throw new StateError('I must be mocked');
@@ -44,6 +44,7 @@ class LongToString {
 
   LongToString(this.aList, this.aMap, this.aString);
 
+  @override
   String toString() => 'LongToString<\n'
       '    aList: $aList\n'
       '    aMap: $aMap\n'
@@ -51,7 +52,7 @@ class LongToString {
       '>';
 }
 
-class MockedClass extends Mock implements RealClass {}
+class _MockedClass extends Mock implements _RealClass {}
 
 expectFail(String expectedMessage, expectedToFail()) {
   try {
@@ -72,12 +73,12 @@ String noMatchingCallsFooter = '(If you called `verify(...).called(0);`, '
     'please instead use `verifyNever(...);`.)';
 
 void main() {
-  MockedClass mock;
+  _MockedClass mock;
 
   var isNsmForwarding = assessNsmForwarding();
 
   setUp(() {
-    mock = new MockedClass();
+    mock = new _MockedClass();
   });
 
   tearDown(() {
@@ -101,13 +102,13 @@ void main() {
       mock.methodWithPositionalArgs(42, 17);
       expectFail(
           'No matching calls. All calls: '
-          'MockedClass.methodWithPositionalArgs(42, 17)\n'
+          '_MockedClass.methodWithPositionalArgs(42, 17)\n'
           '$noMatchingCallsFooter', () {
         verify(mock.methodWithPositionalArgs(42));
       });
       expectFail(
           'No matching calls. All calls: '
-          'MockedClass.methodWithPositionalArgs(42, 17)\n'
+          '_MockedClass.methodWithPositionalArgs(42, 17)\n'
           '$noMatchingCallsFooter', () {
         verify(mock.methodWithPositionalArgs(42, 18));
       });
@@ -118,13 +119,13 @@ void main() {
       mock.methodWithNamedArgs(42, y: 17);
       expectFail(
           'No matching calls. All calls: '
-          'MockedClass.methodWithNamedArgs(42, {y: 17})\n'
+          '_MockedClass.methodWithNamedArgs(42, {y: 17})\n'
           '$noMatchingCallsFooter', () {
         verify(mock.methodWithNamedArgs(42));
       });
       expectFail(
           'No matching calls. All calls: '
-          'MockedClass.methodWithNamedArgs(42, {y: 17})\n'
+          '_MockedClass.methodWithNamedArgs(42, {y: 17})\n'
           '$noMatchingCallsFooter', () {
         verify(mock.methodWithNamedArgs(42, y: 18));
       });
@@ -132,12 +133,12 @@ void main() {
     });
 
     test('should mock method with mock args', () {
-      var m1 = named(new MockedClass(), name: 'm1');
+      var m1 = named(new _MockedClass(), name: 'm1');
       mock.methodWithObjArgs(m1);
       expectFail(
-          'No matching calls. All calls: MockedClass.methodWithObjArgs(m1)\n'
+          'No matching calls. All calls: _MockedClass.methodWithObjArgs(m1)\n'
           '$noMatchingCallsFooter', () {
-        verify(mock.methodWithObjArgs(new MockedClass()));
+        verify(mock.methodWithObjArgs(new _MockedClass()));
       });
       verify(mock.methodWithObjArgs(m1));
     });
@@ -146,7 +147,7 @@ void main() {
       mock.methodWithListArgs([42]);
       expectFail(
           'No matching calls. All calls: '
-          'MockedClass.methodWithListArgs([42])\n'
+          '_MockedClass.methodWithListArgs([42])\n'
           '$noMatchingCallsFooter', () {
         verify(mock.methodWithListArgs([43]));
       });
@@ -157,12 +158,11 @@ void main() {
       mock.methodWithNormalArgs(100);
       expectFail(
           'No matching calls. All calls: '
-          'MockedClass.methodWithNormalArgs(100)\n'
+          '_MockedClass.methodWithNormalArgs(100)\n'
           '$noMatchingCallsFooter', () {
-        verify(mock.methodWithNormalArgs(typed(argThat(greaterThan(100)))));
+        verify(mock.methodWithNormalArgs(argThat(greaterThan(100))));
       });
-      verify(
-          mock.methodWithNormalArgs(typed(argThat(greaterThanOrEqualTo(100)))));
+      verify(mock.methodWithNormalArgs(argThat(greaterThanOrEqualTo(100))));
     });
 
     test('should mock method with mix of argument matchers and real things',
@@ -170,20 +170,19 @@ void main() {
       mock.methodWithPositionalArgs(100, 17);
       expectFail(
           'No matching calls. All calls: '
-          'MockedClass.methodWithPositionalArgs(100, 17)\n'
+          '_MockedClass.methodWithPositionalArgs(100, 17)\n'
           '$noMatchingCallsFooter', () {
         verify(mock.methodWithPositionalArgs(
-            typed(argThat(greaterThanOrEqualTo(100))), 18));
+            argThat(greaterThanOrEqualTo(100)), 18));
       });
       expectFail(
           'No matching calls. All calls: '
-          'MockedClass.methodWithPositionalArgs(100, 17)\n'
+          '_MockedClass.methodWithPositionalArgs(100, 17)\n'
           '$noMatchingCallsFooter', () {
-        verify(mock.methodWithPositionalArgs(
-            typed(argThat(greaterThan(100))), 17));
+        verify(mock.methodWithPositionalArgs(argThat(greaterThan(100)), 17));
       });
       verify(mock.methodWithPositionalArgs(
-          typed(argThat(greaterThanOrEqualTo(100))), 17));
+          argThat(greaterThanOrEqualTo(100)), 17));
     });
 
     test('should mock getter', () {
@@ -194,7 +193,7 @@ void main() {
     test('should mock setter', () {
       mock.setter = 'A';
       expectFail(
-          'No matching calls. All calls: MockedClass.setter==A\n'
+          'No matching calls. All calls: _MockedClass.setter==A\n'
           '$noMatchingCallsFooter', () {
         verify(mock.setter = 'B');
       });
@@ -237,7 +236,7 @@ void main() {
     test('and there is one unmatched call', () {
       mock.methodWithNormalArgs(42);
       expectFail(
-          'No matching calls. All calls: MockedClass.methodWithNormalArgs(42)\n'
+          'No matching calls. All calls: _MockedClass.methodWithNormalArgs(42)\n'
           '$noMatchingCallsFooter', () {
         verify(mock.methodWithNormalArgs(43));
       });
@@ -247,7 +246,7 @@ void main() {
       mock.methodWithOptionalArg();
       var nsmForwardedArgs = isNsmForwarding ? 'null' : '';
       expectFail(
-          'No matching calls. All calls: MockedClass.methodWithOptionalArg($nsmForwardedArgs)\n'
+          'No matching calls. All calls: _MockedClass.methodWithOptionalArg($nsmForwardedArgs)\n'
           '$noMatchingCallsFooter', () {
         verify(mock.methodWithOptionalArg(43));
       });
@@ -258,8 +257,8 @@ void main() {
       mock.methodWithNormalArgs(42);
       expectFail(
           'No matching calls. All calls: '
-          'MockedClass.methodWithNormalArgs(41), '
-          'MockedClass.methodWithNormalArgs(42)\n'
+          '_MockedClass.methodWithNormalArgs(41), '
+          '_MockedClass.methodWithNormalArgs(42)\n'
           '$noMatchingCallsFooter', () {
         verify(mock.methodWithNormalArgs(43));
       });
@@ -270,7 +269,7 @@ void main() {
       var nsmForwardedArgs = isNsmForwarding ? '{y: 1, z: null}' : '{y: 1}';
       expectFail(
           'No matching calls. All calls: '
-          'MockedClass.methodWithOnlyNamedArgs($nsmForwardedArgs)\n'
+          '_MockedClass.methodWithOnlyNamedArgs($nsmForwardedArgs)\n'
           '$noMatchingCallsFooter', () {
         verify(mock.methodWithOnlyNamedArgs());
       });
@@ -379,7 +378,8 @@ void main() {
       test('one fails', () {
         mock.methodWithoutArgs();
         expectFail(
-            'Unexpected calls. All calls: MockedClass.methodWithoutArgs()', () {
+            'Unexpected calls. All calls: _MockedClass.methodWithoutArgs()',
+            () {
           verifyNever(mock.methodWithoutArgs());
         });
       });
@@ -391,7 +391,7 @@ void main() {
         verify(mock.methodWithoutArgs());
         expectFail(
             'No matching calls. '
-            'All calls: [VERIFIED] MockedClass.methodWithoutArgs()\n'
+            'All calls: [VERIFIED] _MockedClass.methodWithoutArgs()\n'
             '$noMatchingCallsFooter', () {
           verify(mock.methodWithoutArgs());
         });
@@ -415,7 +415,7 @@ void main() {
       mock.methodWithoutArgs();
       expectFail(
           'No interaction expected, but following found: '
-          'MockedClass.methodWithoutArgs()', () {
+          '_MockedClass.methodWithoutArgs()', () {
         verifyZeroInteractions(mock);
       });
     });
@@ -425,7 +425,7 @@ void main() {
       verify(mock.methodWithoutArgs());
       expectFail(
           'No interaction expected, but following found: '
-          '[VERIFIED] MockedClass.methodWithoutArgs()', () {
+          '[VERIFIED] _MockedClass.methodWithoutArgs()', () {
         verifyZeroInteractions(mock);
       });
     });
@@ -440,7 +440,7 @@ void main() {
       mock.methodWithoutArgs();
       expectFail(
           'No more calls expected, but following found: '
-          'MockedClass.methodWithoutArgs()', () {
+          '_MockedClass.methodWithoutArgs()', () {
         verifyNoMoreInteractions(mock);
       });
     });
@@ -452,8 +452,8 @@ void main() {
     });
 
     test('throws if given a real object', () {
-      expect(
-          () => verifyNoMoreInteractions(new RealClass()), throwsArgumentError);
+      expect(() => verifyNoMoreInteractions(new _RealClass()),
+          throwsArgumentError);
     });
   });
 
@@ -469,7 +469,7 @@ void main() {
       mock.getter;
       expectFail(
           'Matching call #1 not found. All calls: '
-          'MockedClass.methodWithoutArgs(), MockedClass.getter', () {
+          '_MockedClass.methodWithoutArgs(), _MockedClass.getter', () {
         verifyInOrder([mock.getter, mock.methodWithoutArgs()]);
       });
     });
@@ -478,7 +478,7 @@ void main() {
       mock.methodWithoutArgs();
       expectFail(
           'Matching call #1 not found. All calls: '
-          'MockedClass.methodWithoutArgs()', () {
+          '_MockedClass.methodWithoutArgs()', () {
         verifyInOrder([mock.methodWithoutArgs(), mock.getter]);
       });
     });
@@ -497,8 +497,8 @@ void main() {
       mock.getter;
       expectFail(
           'Matching call #2 not found. All calls: '
-          'MockedClass.methodWithoutArgs(), MockedClass.methodWithoutArgs(), '
-          'MockedClass.getter', () {
+          '_MockedClass.methodWithoutArgs(), _MockedClass.methodWithoutArgs(), '
+          '_MockedClass.getter', () {
         verifyInOrder(
             [mock.methodWithoutArgs(), mock.getter, mock.methodWithoutArgs()]);
       });
@@ -518,7 +518,7 @@ void main() {
           isNsmForwarding ? '>, {c: null, d: null}),' : '>),';
       expectFail(
           'No matching calls. All calls: '
-          'MockedClass.methodWithLongArgs(\n'
+          '_MockedClass.methodWithLongArgs(\n'
           '    LongToString<\n'
           '        aList: [1, 2]\n'
           '        aMap: {1: a, 2: b}\n'
@@ -529,7 +529,7 @@ void main() {
           '        aMap: {3: d, 4: e}\n'
           '        aString: f\n'
           '    $nsmForwardedNamedArgs\n'
-          'MockedClass.methodWithLongArgs(null, null, {\n'
+          '_MockedClass.methodWithLongArgs(null, null, {\n'
           '    c: LongToString<\n'
           '        aList: [5, 6]\n'
           '        aMap: {5: g, 6: h}\n'


### PR DESCRIPTION
This gets rid of analyzer warnings about deprecated APIs, and is a good separation of the tests. Also:

* Privatize test classes, so that analyzer knows if they can be deleted.
* Override things that need overriding.