### PR TITLE
Enforce a _few_ of the --no-strict-dynamic rules

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,12 @@
 analyzer:
- strong-mode:
-   implicit-casts: false
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: false
+  errors:
+    strong_mode_implicit_dynamic_list_literal: ignore
+    strong_mode_implicit_dynamic_map_literal: ignore
+    strong_mode_implicit_dynamic_parameter: ignore
+    strong_mode_implicit_dynamic_variable: ignore
 linter:
   rules:
      # Errors

--- a/lib/src/invocation_matcher.dart
+++ b/lib/src/invocation_matcher.dart
@@ -33,7 +33,7 @@ import 'package:mockito/src/mock.dart';
 /// what a user expects to be called.
 Matcher invokes(
   Symbol memberName, {
-  List positionalArguments: const [],
+  List<dynamic> positionalArguments: const [],
   Map<Symbol, dynamic> namedArguments: const {},
   bool isGetter: false,
   bool isSetter: false,
@@ -156,9 +156,10 @@ class _InvocationMatcher implements Matcher {
       _invocation.memberName == item.memberName &&
       _invocation.isSetter == item.isSetter &&
       _invocation.isGetter == item.isGetter &&
-      const ListEquality(const _MatcherEquality())
+      const ListEquality<dynamic /* Matcher | E */ >(const _MatcherEquality())
           .equals(_invocation.positionalArguments, item.positionalArguments) &&
-      const MapEquality(values: const _MatcherEquality())
+      const MapEquality<dynamic, dynamic /* Matcher | E */ >(
+              values: const _MatcherEquality())
           .equals(_invocation.namedArguments, item.namedArguments);
 }
 

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -39,7 +39,8 @@ void setDefaultResponse(Mock mock, CallPair<dynamic> defaultResponse()) {
 ///
 /// The default behavior when not using this is to always return `null`.
 void throwOnMissingStub(Mock mock) {
-  mock._defaultResponse = () => new CallPair<dynamic>.allInvocations(mock._noSuchMethod);
+  mock._defaultResponse =
+      () => new CallPair<dynamic>.allInvocations(mock._noSuchMethod);
 }
 
 /// Extend or mixin this class to mark the implementation as a [Mock].

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -31,7 +31,7 @@ final List<ArgMatcher> _storedArgs = <ArgMatcher>[];
 final Map<String, ArgMatcher> _storedNamedArgs = <String, ArgMatcher>{};
 
 // Hidden from the public API, used by spy.dart.
-void setDefaultResponse(Mock mock, CallPair defaultResponse()) {
+void setDefaultResponse(Mock mock, CallPair<dynamic> defaultResponse()) {
   mock._defaultResponse = defaultResponse;
 }
 
@@ -39,7 +39,7 @@ void setDefaultResponse(Mock mock, CallPair defaultResponse()) {
 ///
 /// The default behavior when not using this is to always return `null`.
 void throwOnMissingStub(Mock mock) {
-  mock._defaultResponse = () => new CallPair.allInvocations(mock._noSuchMethod);
+  mock._defaultResponse = () => new CallPair<dynamic>.allInvocations(mock._noSuchMethod);
 }
 
 /// Extend or mixin this class to mark the implementation as a [Mock].
@@ -75,27 +75,27 @@ void throwOnMissingStub(Mock mock) {
 /// used within the context of Dart for Web (dart2js, DDC) and Dart for Mobile
 /// (Flutter).
 class Mock {
-  static _answerNull(_) => null;
+  static Null _answerNull(_) => null;
 
-  static const _nullResponse = const CallPair.allInvocations(_answerNull);
+  static const _nullResponse = const CallPair<Null>.allInvocations(_answerNull);
 
   final StreamController<Invocation> _invocationStreamController =
       new StreamController.broadcast();
   final _realCalls = <RealCall>[];
-  final _responses = <CallPair>[];
+  final _responses = <CallPair<dynamic>>[];
 
   String _givenName;
   int _givenHashCode;
 
   _ReturnsCannedResponse _defaultResponse = () => _nullResponse;
 
-  void _setExpected(CallPair cannedResponse) {
+  void _setExpected(CallPair<dynamic> cannedResponse) {
     _responses.add(cannedResponse);
   }
 
   @override
   @visibleForTesting
-  noSuchMethod(Invocation invocation) {
+  dynamic noSuchMethod(Invocation invocation) {
     // noSuchMethod is that 'magic' that allows us to ignore implementing fields
     // and methods and instead define them later at compile-time per instance.
     // See "Emulating Functions and Interactions" on dartlang.org: goo.gl/r3IQUH
@@ -120,7 +120,7 @@ class Mock {
     }
   }
 
-  _noSuchMethod(Invocation invocation) =>
+  dynamic _noSuchMethod(Invocation invocation) =>
       const Object().noSuchMethod(invocation);
 
   @override
@@ -147,7 +147,7 @@ class Mock {
   }
 }
 
-typedef CallPair _ReturnsCannedResponse();
+typedef CallPair<dynamic> _ReturnsCannedResponse();
 
 // When using an [ArgMatcher], we transform our invocation to have knowledge of
 // which arguments are wrapped, and which ones are not. Otherwise we just use
@@ -346,8 +346,8 @@ class PostExpectation<T> {
     return _completeWhen(answer);
   }
 
-  void _completeWhen(Answering answer) {
-    _whenCall._setExpected(answer);
+  void _completeWhen(Answering<T> answer) {
+    _whenCall._setExpected<T>(answer);
     _whenCall = null;
     _whenInProgress = false;
   }
@@ -524,8 +524,8 @@ class _WhenCall {
   final Invocation whenInvocation;
   _WhenCall(this.mock, this.whenInvocation);
 
-  void _setExpected(Answering answer) {
-    mock._setExpected(new CallPair(isInvocation(whenInvocation), answer));
+  void _setExpected<T>(Answering<T> answer) {
+    mock._setExpected(new CallPair<T>(isInvocation(whenInvocation), answer));
   }
 }
 
@@ -651,11 +651,11 @@ Null _registerMatcher(Matcher matcher, bool capture, {String named}) {
 }
 
 class VerificationResult {
-  List captured = [];
+  List<dynamic> captured = [];
   int callCount;
 
   VerificationResult(this.callCount) {
-    captured = new List.from(_capturedArgs, growable: false);
+    captured = new List<dynamic>.from(_capturedArgs, growable: false);
     _capturedArgs.clear();
   }
 

--- a/test/deprecated_apis/capture_test.dart
+++ b/test/deprecated_apis/capture_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ignore_for_file: strong_mode_implicit_dynamic_function
+
 @deprecated
 library mockito.test.deprecated_apis.capture_test;
 

--- a/test/deprecated_apis/mockito_test.dart
+++ b/test/deprecated_apis/mockito_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ignore_for_file: strong_mode_implicit_dynamic_function
+
 @deprecated
 library mockito.test.deprecated_apis.mockito_test;
 
@@ -52,7 +54,7 @@ class MockFoo extends AbstractFoo with Mock {}
 
 class _MockedClass extends Mock implements _RealClass {}
 
-expectFail(String expectedMessage, expectedToFail()) {
+void expectFail(String expectedMessage, dynamic expectedToFail()) {
   try {
     expectedToFail();
     fail("It was expected to fail!");

--- a/test/deprecated_apis/until_called_test.dart
+++ b/test/deprecated_apis/until_called_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ignore_for_file: strong_mode_implicit_dynamic_function
+
 @deprecated
 library mockito.test.deprecated_apis.until_called_test;
 

--- a/test/deprecated_apis/verify_test.dart
+++ b/test/deprecated_apis/verify_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ignore_for_file: strong_mode_implicit_dynamic_function
+
 @deprecated
 library mockito.test.deprecated_apis.verify_test;
 
@@ -55,7 +57,7 @@ class LongToString {
 
 class _MockedClass extends Mock implements _RealClass {}
 
-expectFail(String expectedMessage, expectedToFail()) {
+void expectFail(String expectedMessage, dynamic expectedToFail()) {
   try {
     expectedToFail();
     fail('It was expected to fail!');

--- a/test/invocation_matcher_test.dart
+++ b/test/invocation_matcher_test.dart
@@ -141,10 +141,10 @@ void main() {
 abstract class Interface {
   bool get value;
   set value(value);
-  say(String text);
-  eat(String food, {bool alsoDrink});
-  lie([bool facingDown]);
-  fly({int miles});
+  void say(String text);
+  void eat(String food, {bool alsoDrink});
+  void lie([bool facingDown]);
+  void fly({int miles});
 }
 
 /// An example of a class that captures Invocation objects.
@@ -156,7 +156,7 @@ class Stub implements Interface {
   const Stub();
 
   @override
-  noSuchMethod(Invocation invocation) {
+  void noSuchMethod(Invocation invocation) {
     lastInvocation = invocation;
   }
 }

--- a/test/mockito_test.dart
+++ b/test/mockito_test.dart
@@ -51,7 +51,7 @@ class _MockFoo extends _AbstractFoo with Mock {}
 
 class _MockedClass extends Mock implements _RealClass {}
 
-expectFail(String expectedMessage, expectedToFail()) {
+void expectFail(String expectedMessage, dynamic expectedToFail()) {
   try {
     expectedToFail();
     fail("It was expected to fail!");

--- a/test/verify_test.dart
+++ b/test/verify_test.dart
@@ -54,7 +54,7 @@ class LongToString {
 
 class _MockedClass extends Mock implements _RealClass {}
 
-expectFail(String expectedMessage, expectedToFail()) {
+void expectFail(String expectedMessage, dynamic expectedToFail()) {
   try {
     expectedToFail();
     fail('It was expected to fail!');


### PR DESCRIPTION
@matanlurey WDYT of these rules?

 I think I'm just enforcing return types and type parameters here, except on List and Map literals.