### PR TITLE
Upgrade pkg deps; implement workaround in tests; minor code cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.0-beta+1
+
+- Upgrade package dependencies.
+
 ## 3.0.0-beta
 
 * This release is the first 3.0.0 release featuring the new Mockito 3 API. The

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 Want to contribute? Great! First, read this page (including the small print at the end).
 
 ### Before you contribute
+
 Before we can use your code, you must sign the
 [Google Individual Contributor License Agreement]
 (https://cla.developers.google.com/about/google-individual)
@@ -17,13 +18,14 @@ possibly guide you. Coordinating up front makes it much easier to avoid
 frustration later on.
 
 ### Code reviews
+
 All submissions, including submissions by project members, require review. We
 use GitHub pull requests for this purpose.
 
 ### The small print
+
 Contributions made by corporations are covered by a different agreement than
 the one above, the
-[Software Grant and Corporate Contributor License Agreement]
-(https://cla.developers.google.com/about/google-corporate).
+[Software Grant and Corporate Contributor License Agreement](https://cla.developers.google.com/about/google-corporate).
 
 **NOTE:** This is not an official Google product

--- a/lib/src/call_pair.dart
+++ b/lib/src/call_pair.dart
@@ -29,7 +29,7 @@ class CallPair<T> {
   const CallPair(this.call, this.response);
 
   const CallPair.allInvocations(this.response)
-      : call = const isInstanceOf<Invocation>();
+      : call = const TypeMatcher<Invocation>();
 
   @override
   String toString() => '$CallPair {$call -> $response}';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,10 @@
 name: mockito
-version: 3.0.0-beta
+version: 3.0.0-beta+1
+
 authors:
   - Dmitriy Fibulwinter <fibulwinter@gmail.com>
   - Dart Team <misc@dartlang.org>
+
 description: A mock framework inspired by Mockito.
 homepage: https://github.com/dart-lang/mockito
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,16 +5,17 @@ authors:
   - Dart Team <misc@dartlang.org>
 description: A mock framework inspired by Mockito.
 homepage: https://github.com/dart-lang/mockito
+
 environment:
   sdk: '>=2.0.0-dev.16.0 <2.0.0'
 
 dependencies:
-  collection: '^1.1.0'
-  matcher: '^0.12.0'
-  meta: '^1.0.4'
-  test: '>=0.12.25 <0.13.0'
+  collection: ^1.1.0
+  matcher: ^0.12.0
+  meta: ^1.0.4
+  test: '>=0.12.25 <2.0.0'
 
 dev_dependencies:
-  build_runner: ^0.7.11
+  build_runner: ^0.8.10
   build_test: ^0.10.0
-  build_web_compilers: ^0.3.1
+  build_web_compilers: ^0.4.0

--- a/test/example/iss/iss.dart
+++ b/test/example/iss/iss.dart
@@ -81,4 +81,4 @@ double sphericalDistanceKm(Point<double> p1, Point<double> p2) {
 
 /// Radius of the earth in km.
 const int _radiusOfEarth = 6371;
-double _toRadian(num degree) => degree * PI / 180.0;
+double _toRadian(num degree) => degree * pi / 180.0;


### PR DESCRIPTION
Fixes #145 
Works around https://github.com/dart-lang/sdk/issues/33565

- Upgrade dependencies; in particular, support test 1.0.0
- Fix code to eliminate deprecation notices.
- Generalize test helpers to support RegExp's; this is as a workaround to https://github.com/dart-lang/sdk/issues/33565
- Fix .md link


cc @kevmoo @kwalrath 