### PR TITLE
Throw an error when stubbing a non-mock method

### DIFF
--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -348,6 +348,10 @@ class PostExpectation<T> {
   }
 
   void _completeWhen(Answering<T> answer) {
+    if (_whenCall == null) {
+      throw new StateError(
+          'Mock method was not called within `when()`. Was a real method called?');
+    }
     _whenCall._setExpected<T>(answer);
     _whenCall = null;
     _whenInProgress = false;

--- a/test/mockito_test.dart
+++ b/test/mockito_test.dart
@@ -45,6 +45,8 @@ abstract class _AbstractFoo implements _Foo {
   String bar() => baz();
 
   String baz();
+
+  String quux() => "Real";
 }
 
 class _MockFoo extends _AbstractFoo with Mock {}
@@ -287,6 +289,13 @@ void main() {
         when(mock.methodWithNamedArgs(argThat(equals(42)), y: anyNamed("z")))
             .thenReturn("99");
       }, throwsArgumentError);
+    });
+
+    test("should throw if attempting to stub a real method", () {
+      var foo = new _MockFoo();
+      expect(() {
+        when(foo.quux()).thenReturn("Stub");
+      }, throwsStateError);
     });
   });
 


### PR DESCRIPTION
Fixes #158 

* [x] sanity check internally