### PR TITLE
Change dependency from test to test_api

### DIFF
--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -17,7 +17,7 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 import 'package:mockito/src/call_pair.dart';
 import 'package:mockito/src/invocation_matcher.dart';
-import 'package:test/test.dart';
+import 'package:test_api/test_api.dart';
 
 bool _whenInProgress = false;
 bool _untilCalledInProgress = false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   test_api: ^0.1.1
 
 dev_dependencies:
+  test: ^1.4.0
   build_runner: ^1.0.0
   build_test: ^0.10.0
   build_web_compilers: ^0.4.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   collection: ^1.1.0
   matcher: ^0.12.3
   meta: ^1.0.4
-  test: ^1.2.0
+  test_api: ^0.1.1
 
 dev_dependencies:
   build_runner: ^1.0.0


### PR DESCRIPTION
This removes ~20 transitive dependencies of mockito. For more background see: https://github.com/dart-lang/test/pull/945.  Happy to discuss in person - also did not bump version 