### PR TITLE
Roll test_api version to be compatible with test_core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.2
+
+* Update the internal version of _[test_api](https://pub.dartlang.org/packages/test_api)_ to
+  be compatible with _[test_core](https://pub.dartlang.org/packages/test_core)_.
+
 ## 3.0.1
 
 * Replace the dependency on the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 3.0.1
+version: 3.0.2
 
 authors:
   - Dmitriy Fibulwinter <fibulwinter@gmail.com>
@@ -15,7 +15,7 @@ dependencies:
   collection: ^1.1.0
   matcher: ^0.12.3
   meta: ^1.0.4
-  test_api: ^0.1.1
+  test_api: ^0.2.0
 
 dev_dependencies:
   test: ^1.4.0


### PR DESCRIPTION
Apparently `^` doesn't grab new minor versions if the package itself is < 1.0