### PR TITLE
Touch up message on version incompatibility.

### DIFF
--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -700,7 +700,8 @@ class VerificationResult {
           'Apologies.');
       print('');
       print('To fix: bump your dependency on the test package to something '
-          'like: ^1.4.0');
+          'like: ^1.4.0, or downgrade your dependency on mockito to something '
+          'like: ^3.0.0');
       rethrow;
     }
   }


### PR DESCRIPTION
This will help anyone who has something like `mockito: any` or `mockito: >=3.0.0`