### PR TITLE
Fix pub badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Mock library for Dart inspired by [Mockito](https://github.com/mockito/mockito).
 
-[![Pub](https://img.shields.io/pub/v/mockito.svg)]()
+[![Pub](https://img.shields.io/pub/v/mockito.svg)](https://pub.dartlang.org/packages/mockito)
 [![Build Status](https://travis-ci.org/dart-lang/mockito.svg?branch=master)](https://travis-ci.org/dart-lang/mockito)
 
 Current mock libraries suffer from specifying method names as strings, which


### PR DESCRIPTION
Fixes #178 

Other repos, like dart-lang/angular, just specify a URL. We should too.