### PR TITLE
List Dart Team as first author

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,9 @@
 name: mockito
-version: 4.0.0
+version: 4.0.0+1
 
 authors:
-  - Dmitriy Fibulwinter <fibulwinter@gmail.com>
   - Dart Team <misc@dartlang.org>
+  - Dmitriy Fibulwinter <fibulwinter@gmail.com>
 
 description: A mock framework inspired by Mockito.
 homepage: https://github.com/dart-lang/mockito


### PR DESCRIPTION
Move Dart Team to first author to be consistent with other Dart Team packages