### PR TITLE
Prepare to publish 4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,10 @@
-## 4.1.2
-
-* Produce a meaningful error message if an argument matcher is used outside of
-  stubbing (`when`) or verification (`verify` and `untilCalled`).
-
 ## 4.1.1
 
 * Mark the unexported and accidentally public `setDefaultResponse` as
   deprecated.
 * Mark the not useful, and not generally used, `named` function as deprecated.
+* Produce a meaningful error message if an argument matcher is used outside of
+  stubbing (`when`) or verification (`verify` and `untilCalled`).
 
 ## 4.1.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 4.1.2
+version: 4.1.1
 
 authors:
   - Dmitriy Fibulwinter <fibulwinter@gmail.com>


### PR DESCRIPTION
Bump version back to 4.1.1 and merge the changelog entries since that
version was never published to pub.