### PR TITLE
Fix newly enforced package:pedantic lints

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -5,9 +5,9 @@ import 'package:test/test.dart';
 
 // Real class
 class Cat {
-  String sound() => "Meow";
+  String sound() => 'Meow';
   bool eatFood(String food, {bool hungry}) => true;
-  Future<void> chew() async => print("Chewing...");
+  Future<void> chew() async => print('Chewing...');
   int walk(List<String> places) => 7;
   void sleep() {}
   void hunt(String place, String prey) {}
@@ -42,20 +42,20 @@ void main() {
     verify(cat.sound());
   });
 
-  test("How about some stubbing?", () {
+  test('How about some stubbing?', () {
     // Unstubbed methods return null.
     expect(cat.sound(), null);
 
     // Stub a method before interacting with it.
-    when(cat.sound()).thenReturn("Purr");
-    expect(cat.sound(), "Purr");
+    when(cat.sound()).thenReturn('Purr');
+    expect(cat.sound(), 'Purr');
 
     // You can call it again.
-    expect(cat.sound(), "Purr");
+    expect(cat.sound(), 'Purr');
 
     // Let's change the stub.
-    when(cat.sound()).thenReturn("Meow");
-    expect(cat.sound(), "Meow");
+    when(cat.sound()).thenReturn('Meow');
+    expect(cat.sound(), 'Meow');
 
     // You can stub getters.
     when(cat.lives).thenReturn(9);
@@ -66,48 +66,48 @@ void main() {
     expect(() => cat.lives, throwsRangeError);
 
     // We can calculate a response at call time.
-    var responses = ["Purr", "Meow"];
+    var responses = ['Purr', 'Meow'];
     when(cat.sound()).thenAnswer((_) => responses.removeAt(0));
-    expect(cat.sound(), "Purr");
-    expect(cat.sound(), "Meow");
+    expect(cat.sound(), 'Purr');
+    expect(cat.sound(), 'Meow');
   });
 
-  test("Argument matchers", () {
+  test('Argument matchers', () {
     // You can use plain arguments themselves
-    when(cat.eatFood("fish")).thenReturn(true);
+    when(cat.eatFood('fish')).thenReturn(true);
 
     // ... including collections
-    when(cat.walk(["roof", "tree"])).thenReturn(2);
+    when(cat.walk(['roof', 'tree'])).thenReturn(2);
 
     // ... or matchers
-    when(cat.eatFood(argThat(startsWith("dry")))).thenReturn(false);
+    when(cat.eatFood(argThat(startsWith('dry')))).thenReturn(false);
 
     // ... or mix aguments with matchers
-    when(cat.eatFood(argThat(startsWith("dry")), hungry: true))
+    when(cat.eatFood(argThat(startsWith('dry')), hungry: true))
         .thenReturn(true);
-    expect(cat.eatFood("fish"), isTrue);
-    expect(cat.walk(["roof", "tree"]), equals(2));
-    expect(cat.eatFood("dry food"), isFalse);
-    expect(cat.eatFood("dry food", hungry: true), isTrue);
+    expect(cat.eatFood('fish'), isTrue);
+    expect(cat.walk(['roof', 'tree']), equals(2));
+    expect(cat.eatFood('dry food'), isFalse);
+    expect(cat.eatFood('dry food', hungry: true), isTrue);
 
     // You can also verify using an argument matcher.
-    verify(cat.eatFood("fish"));
-    verify(cat.walk(["roof", "tree"]));
-    verify(cat.eatFood(argThat(contains("food"))));
+    verify(cat.eatFood('fish'));
+    verify(cat.walk(['roof', 'tree']));
+    verify(cat.eatFood(argThat(contains('food'))));
 
     // You can verify setters.
     cat.lives = 9;
     verify(cat.lives = 9);
 
-    cat.hunt("backyard", null);
-    verify(cat.hunt("backyard", null)); // OK: no arg matchers.
+    cat.hunt('backyard', null);
+    verify(cat.hunt('backyard', null)); // OK: no arg matchers.
 
-    cat.hunt("backyard", null);
-    verify(cat.hunt(argThat(contains("yard")),
+    cat.hunt('backyard', null);
+    verify(cat.hunt(argThat(contains('yard')),
         argThat(isNull))); // OK: null is wrapped in an arg matcher.
   });
 
-  test("Named arguments", () {
+  test('Named arguments', () {
     // GOOD: argument matchers include their names.
     when(cat.eatFood(any, hungry: anyNamed('hungry'))).thenReturn(true);
     when(cat.eatFood(any, hungry: argThat(isNotNull, named: 'hungry')))
@@ -117,7 +117,7 @@ void main() {
         .thenReturn(true);
   });
 
-  test("Verifying exact number of invocations / at least x / never", () {
+  test('Verifying exact number of invocations / at least x / never', () {
     cat.sound();
     cat.sound();
     // Exact number of invocations
@@ -133,41 +133,41 @@ void main() {
     verifyNever(cat.eatFood(any));
   });
 
-  test("Verification in order", () {
-    cat.eatFood("Milk");
+  test('Verification in order', () {
+    cat.eatFood('Milk');
     cat.sound();
-    cat.eatFood("Fish");
-    verifyInOrder([cat.eatFood("Milk"), cat.sound(), cat.eatFood("Fish")]);
+    cat.eatFood('Fish');
+    verifyInOrder([cat.eatFood('Milk'), cat.sound(), cat.eatFood('Fish')]);
   });
 
-  test("Making sure interaction(s) never happened on mock", () {
+  test('Making sure interaction(s) never happened on mock', () {
     verifyZeroInteractions(cat);
   });
 
-  test("Finding redundant invocations", () {
+  test('Finding redundant invocations', () {
     cat.sound();
     verify(cat.sound());
     verifyNoMoreInteractions(cat);
   });
 
-  test("Capturing arguments for further assertions", () {
+  test('Capturing arguments for further assertions', () {
     // Simple capture:
-    cat.eatFood("Fish");
-    expect(verify(cat.eatFood(captureAny)).captured.single, "Fish");
+    cat.eatFood('Fish');
+    expect(verify(cat.eatFood(captureAny)).captured.single, 'Fish');
 
     // Capture multiple calls:
-    cat.eatFood("Milk");
-    cat.eatFood("Fish");
-    expect(verify(cat.eatFood(captureAny)).captured, ["Milk", "Fish"]);
+    cat.eatFood('Milk');
+    cat.eatFood('Fish');
+    expect(verify(cat.eatFood(captureAny)).captured, ['Milk', 'Fish']);
 
     // Conditional capture:
-    cat.eatFood("Milk");
-    cat.eatFood("Fish");
+    cat.eatFood('Milk');
+    cat.eatFood('Fish');
     expect(
-        verify(cat.eatFood(captureThat(startsWith("F")))).captured, ["Fish"]);
+        verify(cat.eatFood(captureThat(startsWith('F')))).captured, ['Fish']);
   });
 
-  test("Waiting for an interaction", () async {
+  test('Waiting for an interaction', () async {
     Future<void> chewHelper(Cat cat) {
       return cat.chew();
     }
@@ -177,15 +177,15 @@ void main() {
     await untilCalled(cat.chew()); // This completes when cat.chew() is called.
 
     // Waiting for a call that has already happened.
-    cat.eatFood("Fish");
+    cat.eatFood('Fish');
     await untilCalled(cat.eatFood(any)); // This completes immediately.
   });
 
-  test("Fake class", () {
+  test('Fake class', () {
     // Create a new fake Cat at runtime.
     var cat = FakeCat();
 
-    cat.eatFood("Milk"); // Prints 'Fake eat Milk'.
+    cat.eatFood('Milk'); // Prints 'Fake eat Milk'.
     expect(() => cat.sleep(), throwsUnimplementedError);
   });
 }

--- a/example/iss/iss.dart
+++ b/example/iss/iss.dart
@@ -31,9 +31,7 @@ class IssLocator {
 
   /// Returns the current GPS position in [latitude, longitude] format.
   Future update() async {
-    if (_ongoingRequest == null) {
-      _ongoingRequest = _doUpdate();
-    }
+    _ongoingRequest ??= _doUpdate();
     await _ongoingRequest;
     _ongoingRequest = null;
   }
@@ -41,7 +39,7 @@ class IssLocator {
   Future _doUpdate() async {
     // Returns the point on the earth directly under the space station
     // at this moment.
-    Response rs = await client.get('http://api.open-notify.org/iss-now.json');
+    var rs = await client.get('http://api.open-notify.org/iss-now.json');
     var data = jsonDecode(rs.body);
     var latitude = double.parse(data['iss_position']['latitude'] as String);
     var longitude = double.parse(data['iss_position']['longitude'] as String);
@@ -60,7 +58,7 @@ class IssSpotter {
   // The ISS is defined to be visible if the distance from the observer to
   // the point on the earth directly under the space station is less than 80km.
   bool get isVisible {
-    double distance = sphericalDistanceKm(locator.currentPosition, observer);
+    var distance = sphericalDistanceKm(locator.currentPosition, observer);
     return distance < 80.0;
   }
 }

--- a/example/iss/iss_test.dart
+++ b/example/iss/iss_test.dart
@@ -27,18 +27,18 @@ void main() {
   // verify the calculated distance between them.
   group('Spherical distance', () {
     test('London - Paris', () {
-      Point<double> london = Point(51.5073, -0.1277);
-      Point<double> paris = Point(48.8566, 2.3522);
-      double d = sphericalDistanceKm(london, paris);
+      var london = Point(51.5073, -0.1277);
+      var paris = Point(48.8566, 2.3522);
+      var d = sphericalDistanceKm(london, paris);
       // London should be approximately 343.5km
       // (+/- 0.1km) from Paris.
       expect(d, closeTo(343.5, 0.1));
     });
 
     test('San Francisco - Mountain View', () {
-      Point<double> sf = Point(37.783333, -122.416667);
-      Point<double> mtv = Point(37.389444, -122.081944);
-      double d = sphericalDistanceKm(sf, mtv);
+      var sf = Point(37.783333, -122.416667);
+      var mtv = Point(37.389444, -122.081944);
+      var d = sphericalDistanceKm(sf, mtv);
       // San Francisco should be approximately 52.8km
       // (+/- 0.1km) from Mountain View.
       expect(d, closeTo(52.8, 0.1));
@@ -52,8 +52,8 @@ void main() {
   // second predefined location. This test runs asynchronously.
   group('ISS spotter', () {
     test('ISS visible', () async {
-      Point<double> sf = Point(37.783333, -122.416667);
-      Point<double> mtv = Point(37.389444, -122.081944);
+      var sf = Point(37.783333, -122.416667);
+      var mtv = Point(37.389444, -122.081944);
       IssLocator locator = MockIssLocator();
       // Mountain View should be visible from San Francisco.
       when(locator.currentPosition).thenReturn(sf);
@@ -63,8 +63,8 @@ void main() {
     });
 
     test('ISS not visible', () async {
-      Point<double> london = Point(51.5073, -0.1277);
-      Point<double> mtv = Point(37.389444, -122.081944);
+      var london = Point(51.5073, -0.1277);
+      var mtv = Point(37.389444, -122.081944);
       IssLocator locator = MockIssLocator();
       // London should not be visible from Mountain View.
       when(locator.currentPosition).thenReturn(london);

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -17,6 +17,7 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 import 'package:mockito/src/call_pair.dart';
 import 'package:mockito/src/invocation_matcher.dart';
+// ignore: deprecated_member_use
 import 'package:test_api/test_api.dart';
 // TODO(srawlins): Remove this when we no longer need to check for an
 // incompatiblity between test_api and test.
@@ -37,7 +38,8 @@ final Map<String, ArgMatcher> _storedNamedArgs = <String, ArgMatcher>{};
 @Deprecated(
     'This function is not a supported function, and may be deleted as early as '
     'Mockito 5.0.0')
-void setDefaultResponse(Mock mock, CallPair<dynamic> defaultResponse()) {
+void setDefaultResponse(
+    Mock mock, CallPair<dynamic> Function() defaultResponse) {
   mock._defaultResponse = defaultResponse;
 }
 
@@ -136,7 +138,7 @@ class Mock {
       const Object().noSuchMethod(invocation);
 
   @override
-  int get hashCode => _givenHashCode == null ? 0 : _givenHashCode;
+  int get hashCode => _givenHashCode ?? 0;
 
   @override
   bool operator ==(other) => (_givenHashCode != null && other is Mock)
@@ -144,7 +146,7 @@ class Mock {
       : identical(this, other);
 
   @override
-  String toString() => _givenName != null ? _givenName : runtimeType.toString();
+  String toString() => _givenName ?? runtimeType.toString();
 
   String _realCallsToString() {
     var stringRepresentations = _realCalls.map((call) => call.toString());
@@ -238,7 +240,7 @@ class _InvocationForMatchedArguments extends Invocation {
   factory _InvocationForMatchedArguments(Invocation invocation) {
     if (_storedArgs.isEmpty && _storedNamedArgs.isEmpty) {
       throw StateError(
-          "_InvocationForMatchedArguments called when no ArgMatchers have been saved.");
+          '_InvocationForMatchedArguments called when no ArgMatchers have been saved.');
     }
 
     // Handle named arguments first, so that we can provide useful errors for
@@ -289,7 +291,7 @@ class _InvocationForMatchedArguments extends Invocation {
     // Iterate through the stored named args, validate them, and add them to
     // the return map.
     _storedNamedArgs.forEach((name, arg) {
-      Symbol nameSymbol = Symbol(name);
+      var nameSymbol = Symbol(name);
       if (!invocation.namedArguments.containsKey(nameSymbol)) {
         // Clear things out for the next call.
         _storedArgs.clear();
@@ -344,8 +346,8 @@ class _InvocationForMatchedArguments extends Invocation {
           'needs to specify the name of the argument it is being used in. For '
           'example: `when(obj.fn(x: anyNamed("x")))`).');
     }
-    int storedIndex = 0;
-    int positionalIndex = 0;
+    var storedIndex = 0;
+    var positionalIndex = 0;
     while (storedIndex < _storedArgs.length &&
         positionalIndex < invocation.positionalArguments.length) {
       var arg = _storedArgs[storedIndex];
@@ -456,7 +458,7 @@ class InvocationMatcher {
   }
 
   void _captureArguments(Invocation invocation) {
-    int index = 0;
+    var index = 0;
     for (var roleArg in roleInvocation.positionalArguments) {
       var actArg = invocation.positionalArguments[index];
       if (roleArg is ArgMatcher && roleArg._capture) {
@@ -484,7 +486,7 @@ class InvocationMatcher {
         roleInvocation.namedArguments.length) {
       return false;
     }
-    int index = 0;
+    var index = 0;
     for (var roleArg in roleInvocation.positionalArguments) {
       var actArg = invocation.positionalArguments[index];
       if (!isMatchingArg(roleArg, actArg)) {
@@ -541,8 +543,7 @@ class RealCall {
   @override
   String toString() {
     var argString = '';
-    var args = invocation.positionalArguments
-        .map((v) => v == null ? "null" : v.toString());
+    var args = invocation.positionalArguments.map((v) => '$v');
     if (args.any((arg) => arg.contains('\n'))) {
       // As one or more arg contains newlines, put each on its own line, and
       // indent each, for better readability.
@@ -649,18 +650,18 @@ class _VerifyCall {
     if (!never && matchingInvocations.isEmpty) {
       var message;
       if (mock._realCalls.isEmpty) {
-        message = "No matching calls (actually, no calls at all).";
+        message = 'No matching calls (actually, no calls at all).';
       } else {
         var otherCalls = mock._realCallsToString();
-        message = "No matching calls. All calls: $otherCalls";
+        message = 'No matching calls. All calls: $otherCalls';
       }
-      fail("$message\n"
-          "(If you called `verify(...).called(0);`, please instead use "
-          "`verifyNever(...);`.)");
+      fail('$message\n'
+          '(If you called `verify(...).called(0);`, please instead use '
+          '`verifyNever(...);`.)');
     }
     if (never && matchingInvocations.isNotEmpty) {
       var calls = mock._realCallsToString();
-      fail("Unexpected calls. All calls: $calls");
+      fail('Unexpected calls. All calls: $calls');
     }
     matchingInvocations.forEach((inv) {
       inv.verified = true;
@@ -873,7 +874,7 @@ class VerificationResult {
       _checkTestApiMismatch();
     }
     expect(callCount, wrapMatcher(matcher),
-        reason: "Unexpected number of calls");
+        reason: 'Unexpected number of calls');
   }
 }
 
@@ -939,12 +940,12 @@ Verification _makeVerify(bool never) {
   return <T>(T mock) {
     _verificationInProgress = false;
     if (_verifyCalls.length == 1) {
-      _VerifyCall verifyCall = _verifyCalls.removeLast();
+      var verifyCall = _verifyCalls.removeLast();
       var result = VerificationResult._(verifyCall.matchingInvocations.length);
       verifyCall._checkWith(never);
       return result;
     } else {
-      fail("Used on a non-mockito object");
+      fail('Used on a non-mockito object');
     }
   };
 }
@@ -970,23 +971,22 @@ _InOrderVerification get verifyInOrder {
   _verificationInProgress = true;
   return <T>(List<T> _) {
     _verificationInProgress = false;
-    DateTime dt = DateTime.fromMillisecondsSinceEpoch(0);
+    var dt = DateTime.fromMillisecondsSinceEpoch(0);
     var tmpVerifyCalls = List<_VerifyCall>.from(_verifyCalls);
     _verifyCalls.clear();
-    List<RealCall> matchedCalls = [];
-    for (_VerifyCall verifyCall in tmpVerifyCalls) {
-      RealCall matched = verifyCall._findAfter(dt);
+    var matchedCalls = <RealCall>[];
+    for (var verifyCall in tmpVerifyCalls) {
+      var matched = verifyCall._findAfter(dt);
       if (matched != null) {
         matchedCalls.add(matched);
         dt = matched.timeStamp;
       } else {
-        Set<Mock> mocks =
-            tmpVerifyCalls.map((_VerifyCall vc) => vc.mock).toSet();
-        List<RealCall> allInvocations =
+        var mocks = tmpVerifyCalls.map((vc) => vc.mock).toSet();
+        var allInvocations =
             mocks.expand((m) => m._realCalls).toList(growable: false);
         allInvocations
             .sort((inv1, inv2) => inv1.timeStamp.compareTo(inv2.timeStamp));
-        String otherCalls = "";
+        var otherCalls = '';
         if (allInvocations.isNotEmpty) {
           otherCalls = " All calls: ${allInvocations.join(", ")}";
         }
@@ -1011,7 +1011,7 @@ void verifyNoMoreInteractions(var mock) {
   if (mock is Mock) {
     var unverified = mock._realCalls.where((inv) => !inv.verified).toList();
     if (unverified.isNotEmpty) {
-      fail("No more calls expected, but following found: " + unverified.join());
+      fail('No more calls expected, but following found: ' + unverified.join());
     }
   } else {
     _throwMockArgumentError('verifyNoMoreInteractions', mock);
@@ -1021,7 +1021,7 @@ void verifyNoMoreInteractions(var mock) {
 void verifyZeroInteractions(var mock) {
   if (mock is Mock) {
     if (mock._realCalls.isNotEmpty) {
-      fail("No interaction expected, but following found: " +
+      fail('No interaction expected, but following found: ' +
           mock._realCalls.join());
     }
   } else {
@@ -1084,7 +1084,7 @@ InvocationLoader get untilCalled {
 
 /// Print all collected invocations of any mock methods of [mocks].
 void logInvocations(List<Mock> mocks) {
-  List<RealCall> allInvocations =
+  var allInvocations =
       mocks.expand((m) => m._realCalls).toList(growable: false);
   allInvocations.sort((inv1, inv2) => inv1.timeStamp.compareTo(inv2.timeStamp));
   allInvocations.forEach((inv) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 4.1.1
+version: 4.1.2-dev
 
 authors:
   - Dmitriy Fibulwinter <fibulwinter@gmail.com>

--- a/test/capture_test.dart
+++ b/test/capture_test.dart
@@ -22,7 +22,7 @@ class _RealClass {
   String methodWithNormalArgs(int x) => 'Real';
   String methodWithListArgs(List<int> x) => 'Real';
   String methodWithPositionalArgs(int x, [int y]) => 'Real';
-  String methodWithTwoNamedArgs(int x, {int y, int z}) => "Real";
+  String methodWithTwoNamedArgs(int x, {int y, int z}) => 'Real';
   set setter(String arg) {
     throw StateError('I must be mocked');
   }

--- a/test/deprecated_apis/mockito_test.dart
+++ b/test/deprecated_apis/mockito_test.dart
@@ -24,18 +24,18 @@ import 'package:test/test.dart';
 
 class _RealClass {
   _RealClass innerObj;
-  String methodWithoutArgs() => "Real";
-  String methodWithNormalArgs(int x) => "Real";
-  String methodWithListArgs(List<int> x) => "Real";
-  String methodWithPositionalArgs(int x, [int y]) => "Real";
-  String methodWithNamedArgs(int x, {int y}) => "Real";
-  String methodWithTwoNamedArgs(int x, {int y, int z}) => "Real";
-  String methodWithObjArgs(_RealClass x) => "Real";
-  Future<String> methodReturningFuture() => Future.value("Real");
-  Stream<String> methodReturningStream() => Stream.fromIterable(["Real"]);
-  String get getter => "Real";
+  String methodWithoutArgs() => 'Real';
+  String methodWithNormalArgs(int x) => 'Real';
+  String methodWithListArgs(List<int> x) => 'Real';
+  String methodWithPositionalArgs(int x, [int y]) => 'Real';
+  String methodWithNamedArgs(int x, {int y}) => 'Real';
+  String methodWithTwoNamedArgs(int x, {int y, int z}) => 'Real';
+  String methodWithObjArgs(_RealClass x) => 'Real';
+  Future<String> methodReturningFuture() => Future.value('Real');
+  Stream<String> methodReturningStream() => Stream.fromIterable(['Real']);
+  String get getter => 'Real';
   set setter(String arg) {
-    throw StateError("I must be mocked");
+    throw StateError('I must be mocked');
   }
 }
 
@@ -54,23 +54,23 @@ class MockFoo extends AbstractFoo with Mock {}
 
 class _MockedClass extends Mock implements _RealClass {}
 
-void expectFail(String expectedMessage, dynamic expectedToFail()) {
+void expectFail(String expectedMessage, void Function() expectedToFail) {
   try {
     expectedToFail();
-    fail("It was expected to fail!");
+    fail('It was expected to fail!');
   } catch (e) {
     if (!(e is TestFailure)) {
       rethrow;
     } else {
       if (expectedMessage != e.message) {
-        throw TestFailure("Failed, but with wrong message: ${e.message}");
+        throw TestFailure('Failed, but with wrong message: ${e.message}');
       }
     }
   }
 }
 
-String noMatchingCallsFooter = "(If you called `verify(...).called(0);`, "
-    "please instead use `verifyNever(...);`.)";
+String noMatchingCallsFooter = '(If you called `verify(...).called(0);`, '
+    'please instead use `verifyNever(...);`.)';
 
 void main() {
   _MockedClass mock;
@@ -85,67 +85,67 @@ void main() {
     resetMockitoState();
   });
 
-  group("when()", () {
-    test("should mock method with argument matcher", () {
+  group('when()', () {
+    test('should mock method with argument matcher', () {
       when(mock.methodWithNormalArgs(typed(argThat(greaterThan(100)))))
-          .thenReturn("A lot!");
+          .thenReturn('A lot!');
       expect(mock.methodWithNormalArgs(100), isNull);
-      expect(mock.methodWithNormalArgs(101), equals("A lot!"));
+      expect(mock.methodWithNormalArgs(101), equals('A lot!'));
     });
 
-    test("should mock method with any argument matcher", () {
-      when(mock.methodWithNormalArgs(typed(any))).thenReturn("A lot!");
-      expect(mock.methodWithNormalArgs(100), equals("A lot!"));
-      expect(mock.methodWithNormalArgs(101), equals("A lot!"));
+    test('should mock method with any argument matcher', () {
+      when(mock.methodWithNormalArgs(typed(any))).thenReturn('A lot!');
+      expect(mock.methodWithNormalArgs(100), equals('A lot!'));
+      expect(mock.methodWithNormalArgs(101), equals('A lot!'));
     });
 
-    test("should mock method with any list argument matcher", () {
-      when(mock.methodWithListArgs(typed(any))).thenReturn("A lot!");
-      expect(mock.methodWithListArgs([42]), equals("A lot!"));
-      expect(mock.methodWithListArgs([43]), equals("A lot!"));
+    test('should mock method with any list argument matcher', () {
+      when(mock.methodWithListArgs(typed(any))).thenReturn('A lot!');
+      expect(mock.methodWithListArgs([42]), equals('A lot!'));
+      expect(mock.methodWithListArgs([43]), equals('A lot!'));
     });
 
-    test("should mock method with mix of argument matchers and real things",
+    test('should mock method with mix of argument matchers and real things',
         () {
       when(mock.methodWithPositionalArgs(typed(argThat(greaterThan(100))), 17))
-          .thenReturn("A lot with 17");
+          .thenReturn('A lot with 17');
       expect(mock.methodWithPositionalArgs(100, 17), isNull);
       expect(mock.methodWithPositionalArgs(101, 18), isNull);
-      expect(mock.methodWithPositionalArgs(101, 17), equals("A lot with 17"));
+      expect(mock.methodWithPositionalArgs(101, 17), equals('A lot with 17'));
     });
 
     //no need to mock setter, except if we will have spies later...
-    test("should mock method with thrown result", () {
+    test('should mock method with thrown result', () {
       when(mock.methodWithNormalArgs(typed(any))).thenThrow(StateError('Boo'));
       expect(() => mock.methodWithNormalArgs(42), throwsStateError);
     });
 
-    test("should mock method with calculated result", () {
+    test('should mock method with calculated result', () {
       when(mock.methodWithNormalArgs(typed(any))).thenAnswer(
           (Invocation inv) => inv.positionalArguments[0].toString());
-      expect(mock.methodWithNormalArgs(43), equals("43"));
-      expect(mock.methodWithNormalArgs(42), equals("42"));
+      expect(mock.methodWithNormalArgs(43), equals('43'));
+      expect(mock.methodWithNormalArgs(42), equals('42'));
     });
 
-    test("should mock method with calculated result", () {
+    test('should mock method with calculated result', () {
       when(mock.methodWithNormalArgs(typed(argThat(equals(43)))))
-          .thenReturn("43");
+          .thenReturn('43');
       when(mock.methodWithNormalArgs(typed(argThat(equals(42)))))
-          .thenReturn("42");
-      expect(mock.methodWithNormalArgs(43), equals("43"));
+          .thenReturn('42');
+      expect(mock.methodWithNormalArgs(43), equals('43'));
     });
 
-    test("should mock hashCode", () {
+    test('should mock hashCode', () {
       named(mock, hashCode: 42);
       expect(mock.hashCode, equals(42));
     });
 
-    test("should have toString as name when it is not mocked", () {
-      named(mock, name: "Cat");
-      expect(mock.toString(), equals("Cat"));
+    test('should have toString as name when it is not mocked', () {
+      named(mock, name: 'Cat');
+      expect(mock.toString(), equals('Cat'));
     });
 
-    test("should mock equals between mocks when givenHashCode is equals", () {
+    test('should mock equals between mocks when givenHashCode is equals', () {
       var anotherMock = named(_MockedClass(), hashCode: 42);
       named(mock, hashCode: 42);
       expect(mock == anotherMock, isTrue);

--- a/test/deprecated_apis/until_called_test.dart
+++ b/test/deprecated_apis/until_called_test.dart
@@ -86,8 +86,7 @@ void main() {
   });
 
   group('untilCalled', () {
-    StreamController<CallMethodsEvent> streamController =
-        StreamController.broadcast();
+    var streamController = StreamController<CallMethodsEvent>.broadcast();
 
     group('on methods already called', () {
       test('waits for method with normal args', () async {

--- a/test/deprecated_apis/verify_test.dart
+++ b/test/deprecated_apis/verify_test.dart
@@ -57,7 +57,7 @@ class LongToString {
 
 class _MockedClass extends Mock implements _RealClass {}
 
-void expectFail(String expectedMessage, dynamic expectedToFail()) {
+void expectFail(String expectedMessage, void Function() expectedToFail) {
   try {
     expectedToFail();
     fail('It was expected to fail!');

--- a/test/invocation_matcher_test.dart
+++ b/test/invocation_matcher_test.dart
@@ -66,9 +66,9 @@ void main() {
       shouldFail(
         call1,
         isInvocation(call3),
-        "Expected: lie(<false>) "
+        'Expected: lie(<false>) '
         "Actual: <Instance of '${call3.runtimeType}'> "
-        "Which: Does not match lie(<true>)",
+        'Which: Does not match lie(<true>)',
       );
     });
 
@@ -102,9 +102,9 @@ void main() {
         call1,
         isInvocation(call3),
         // RegExp needed because of https://github.com/dart-lang/sdk/issues/33565
-        RegExp("Expected: set value=? <false> "
+        RegExp('Expected: set value=? <false> '
             "Actual: <Instance of '${call3.runtimeType}'> "
-            "Which: Does not match set value=? <true>"),
+            'Which: Does not match set value=? <true>'),
       );
     });
   });
@@ -118,7 +118,7 @@ void main() {
       shouldFail(
         call,
         invokes(#say, positionalArguments: [isNull]),
-        "Expected: say(null) "
+        'Expected: say(null) '
         "Actual: <Instance of '${call.runtimeType}'> "
         "Which: Does not match say('Hello')",
       );

--- a/test/mockito_test.dart
+++ b/test/mockito_test.dart
@@ -21,16 +21,16 @@ import 'utils.dart';
 
 class _RealClass {
   _RealClass innerObj;
-  String methodWithoutArgs() => "Real";
-  String methodWithNormalArgs(int x) => "Real";
-  String methodWithListArgs(List<int> x) => "Real";
-  String methodWithPositionalArgs(int x, [int y]) => "Real";
-  String methodWithNamedArgs(int x, {int y}) => "Real";
-  String methodWithTwoNamedArgs(int x, {int y, int z}) => "Real";
-  String methodWithObjArgs(_RealClass x) => "Real";
-  Future<String> methodReturningFuture() => Future.value("Real");
-  Stream<String> methodReturningStream() => Stream.fromIterable(["Real"]);
-  String get getter => "Real";
+  String methodWithoutArgs() => 'Real';
+  String methodWithNormalArgs(int x) => 'Real';
+  String methodWithListArgs(List<int> x) => 'Real';
+  String methodWithPositionalArgs(int x, [int y]) => 'Real';
+  String methodWithNamedArgs(int x, {int y}) => 'Real';
+  String methodWithTwoNamedArgs(int x, {int y, int z}) => 'Real';
+  String methodWithObjArgs(_RealClass x) => 'Real';
+  Future<String> methodReturningFuture() => Future.value('Real');
+  Stream<String> methodReturningStream() => Stream.fromIterable(['Real']);
+  String get getter => 'Real';
 }
 
 abstract class _Foo {
@@ -43,30 +43,30 @@ abstract class _AbstractFoo implements _Foo {
 
   String baz();
 
-  String quux() => "Real";
+  String quux() => 'Real';
 }
 
 class _MockFoo extends _AbstractFoo with Mock {}
 
 class _MockedClass extends Mock implements _RealClass {}
 
-void expectFail(String expectedMessage, dynamic expectedToFail()) {
+void expectFail(String expectedMessage, void Function() expectedToFail) {
   try {
     expectedToFail();
-    fail("It was expected to fail!");
+    fail('It was expected to fail!');
   } catch (e) {
     if (!(e is TestFailure)) {
       rethrow;
     } else {
       if (expectedMessage != e.message) {
-        throw TestFailure("Failed, but with wrong message: ${e.message}");
+        throw TestFailure('Failed, but with wrong message: ${e.message}');
       }
     }
   }
 }
 
-String noMatchingCallsFooter = "(If you called `verify(...).called(0);`, "
-    "please instead use `verifyNever(...);`.)";
+String noMatchingCallsFooter = '(If you called `verify(...).called(0);`, '
+    'please instead use `verifyNever(...);`.)';
 
 void main() {
   _MockedClass mock;
@@ -83,229 +83,229 @@ void main() {
     resetMockitoState();
   });
 
-  group("mixin support", () {
-    test("should work", () {
+  group('mixin support', () {
+    test('should work', () {
       var foo = _MockFoo();
       when(foo.baz()).thenReturn('baz');
       expect(foo.bar(), 'baz');
     });
   });
 
-  group("when()", () {
-    test("should mock method without args", () {
-      when(mock.methodWithoutArgs()).thenReturn("A");
-      expect(mock.methodWithoutArgs(), equals("A"));
+  group('when()', () {
+    test('should mock method without args', () {
+      when(mock.methodWithoutArgs()).thenReturn('A');
+      expect(mock.methodWithoutArgs(), equals('A'));
     });
 
-    test("should mock method with normal args", () {
-      when(mock.methodWithNormalArgs(42)).thenReturn("Ultimate Answer");
+    test('should mock method with normal args', () {
+      when(mock.methodWithNormalArgs(42)).thenReturn('Ultimate Answer');
       expect(mock.methodWithNormalArgs(43), isNull);
-      expect(mock.methodWithNormalArgs(42), equals("Ultimate Answer"));
+      expect(mock.methodWithNormalArgs(42), equals('Ultimate Answer'));
     });
 
-    test("should mock method with mock args", () {
+    test('should mock method with mock args', () {
       var m1 = _MockedClass();
-      when(mock.methodWithObjArgs(m1)).thenReturn("Ultimate Answer");
+      when(mock.methodWithObjArgs(m1)).thenReturn('Ultimate Answer');
       expect(mock.methodWithObjArgs(_MockedClass()), isNull);
-      expect(mock.methodWithObjArgs(m1), equals("Ultimate Answer"));
+      expect(mock.methodWithObjArgs(m1), equals('Ultimate Answer'));
     });
 
-    test("should mock method with positional args", () {
-      when(mock.methodWithPositionalArgs(42, 17)).thenReturn("Answer and...");
+    test('should mock method with positional args', () {
+      when(mock.methodWithPositionalArgs(42, 17)).thenReturn('Answer and...');
       expect(mock.methodWithPositionalArgs(42), isNull);
       expect(mock.methodWithPositionalArgs(42, 18), isNull);
-      expect(mock.methodWithPositionalArgs(42, 17), equals("Answer and..."));
+      expect(mock.methodWithPositionalArgs(42, 17), equals('Answer and...'));
     });
 
-    test("should mock method with named args", () {
-      when(mock.methodWithNamedArgs(42, y: 17)).thenReturn("Why answer?");
+    test('should mock method with named args', () {
+      when(mock.methodWithNamedArgs(42, y: 17)).thenReturn('Why answer?');
       expect(mock.methodWithNamedArgs(42), isNull);
       expect(mock.methodWithNamedArgs(42, y: 18), isNull);
-      expect(mock.methodWithNamedArgs(42, y: 17), equals("Why answer?"));
+      expect(mock.methodWithNamedArgs(42, y: 17), equals('Why answer?'));
     });
 
-    test("should mock method with List args", () {
-      when(mock.methodWithListArgs([42])).thenReturn("Ultimate answer");
+    test('should mock method with List args', () {
+      when(mock.methodWithListArgs([42])).thenReturn('Ultimate answer');
       expect(mock.methodWithListArgs([43]), isNull);
-      expect(mock.methodWithListArgs([42]), equals("Ultimate answer"));
+      expect(mock.methodWithListArgs([42]), equals('Ultimate answer'));
     });
 
-    test("should mock method with argument matcher", () {
+    test('should mock method with argument matcher', () {
       when(mock.methodWithNormalArgs(argThat(greaterThan(100))))
-          .thenReturn("A lot!");
+          .thenReturn('A lot!');
       expect(mock.methodWithNormalArgs(100), isNull);
-      expect(mock.methodWithNormalArgs(101), equals("A lot!"));
+      expect(mock.methodWithNormalArgs(101), equals('A lot!'));
     });
 
-    test("should mock method with any argument matcher", () {
-      when(mock.methodWithNormalArgs(any)).thenReturn("A lot!");
-      expect(mock.methodWithNormalArgs(100), equals("A lot!"));
-      expect(mock.methodWithNormalArgs(101), equals("A lot!"));
+    test('should mock method with any argument matcher', () {
+      when(mock.methodWithNormalArgs(any)).thenReturn('A lot!');
+      expect(mock.methodWithNormalArgs(100), equals('A lot!'));
+      expect(mock.methodWithNormalArgs(101), equals('A lot!'));
     });
 
-    test("should mock method with any list argument matcher", () {
-      when(mock.methodWithListArgs(any)).thenReturn("A lot!");
-      expect(mock.methodWithListArgs([42]), equals("A lot!"));
-      expect(mock.methodWithListArgs([43]), equals("A lot!"));
+    test('should mock method with any list argument matcher', () {
+      when(mock.methodWithListArgs(any)).thenReturn('A lot!');
+      expect(mock.methodWithListArgs([42]), equals('A lot!'));
+      expect(mock.methodWithListArgs([43]), equals('A lot!'));
     });
 
-    test("should mock method with multiple named args and matchers", () {
+    test('should mock method with multiple named args and matchers', () {
       when(mock.methodWithTwoNamedArgs(any, y: anyNamed('y')))
-          .thenReturn("x y");
+          .thenReturn('x y');
       when(mock.methodWithTwoNamedArgs(any, z: anyNamed('z')))
-          .thenReturn("x z");
+          .thenReturn('x z');
       if (isNsmForwarding) {
-        expect(mock.methodWithTwoNamedArgs(42), "x z");
+        expect(mock.methodWithTwoNamedArgs(42), 'x z');
       } else {
         expect(mock.methodWithTwoNamedArgs(42), isNull);
       }
-      expect(mock.methodWithTwoNamedArgs(42, y: 18), equals("x y"));
-      expect(mock.methodWithTwoNamedArgs(42, z: 17), equals("x z"));
+      expect(mock.methodWithTwoNamedArgs(42, y: 18), equals('x y'));
+      expect(mock.methodWithTwoNamedArgs(42, z: 17), equals('x z'));
       expect(mock.methodWithTwoNamedArgs(42, y: 18, z: 17), isNull);
       when(mock.methodWithTwoNamedArgs(any, y: anyNamed('y'), z: anyNamed('z')))
-          .thenReturn("x y z");
-      expect(mock.methodWithTwoNamedArgs(42, y: 18, z: 17), equals("x y z"));
+          .thenReturn('x y z');
+      expect(mock.methodWithTwoNamedArgs(42, y: 18, z: 17), equals('x y z'));
     });
 
-    test("should mock method with mix of argument matchers and real things",
+    test('should mock method with mix of argument matchers and real things',
         () {
       when(mock.methodWithPositionalArgs(argThat(greaterThan(100)), 17))
-          .thenReturn("A lot with 17");
+          .thenReturn('A lot with 17');
       expect(mock.methodWithPositionalArgs(100, 17), isNull);
       expect(mock.methodWithPositionalArgs(101, 18), isNull);
-      expect(mock.methodWithPositionalArgs(101, 17), equals("A lot with 17"));
+      expect(mock.methodWithPositionalArgs(101, 17), equals('A lot with 17'));
     });
 
-    test("should mock getter", () {
-      when(mock.getter).thenReturn("A");
-      expect(mock.getter, equals("A"));
+    test('should mock getter', () {
+      when(mock.getter).thenReturn('A');
+      expect(mock.getter, equals('A'));
     });
 
-    test("should have hashCode when it is not mocked", () {
+    test('should have hashCode when it is not mocked', () {
       expect(mock.hashCode, isNotNull);
     });
 
-    test("should have default toString when it is not mocked", () {
-      expect(mock.toString(), equals("_MockedClass"));
+    test('should have default toString when it is not mocked', () {
+      expect(mock.toString(), equals('_MockedClass'));
     });
 
-    test("should use identical equality between it is not mocked", () {
+    test('should use identical equality between it is not mocked', () {
       var anotherMock = _MockedClass();
       expect(mock == anotherMock, isFalse);
       expect(mock == mock, isTrue);
     });
 
-    test("should mock method with thrown result", () {
+    test('should mock method with thrown result', () {
       when(mock.methodWithNormalArgs(any)).thenThrow(StateError('Boo'));
       expect(() => mock.methodWithNormalArgs(42), throwsStateError);
     });
 
-    test("should mock method with calculated result", () {
+    test('should mock method with calculated result', () {
       when(mock.methodWithNormalArgs(any)).thenAnswer(
           (Invocation inv) => inv.positionalArguments[0].toString());
-      expect(mock.methodWithNormalArgs(43), equals("43"));
-      expect(mock.methodWithNormalArgs(42), equals("42"));
+      expect(mock.methodWithNormalArgs(43), equals('43'));
+      expect(mock.methodWithNormalArgs(42), equals('42'));
     });
 
-    test("should return mock to make simple oneline mocks", () {
+    test('should return mock to make simple oneline mocks', () {
       _RealClass mockWithSetup = _MockedClass();
-      when(mockWithSetup.methodWithoutArgs()).thenReturn("oneline");
-      expect(mockWithSetup.methodWithoutArgs(), equals("oneline"));
+      when(mockWithSetup.methodWithoutArgs()).thenReturn('oneline');
+      expect(mockWithSetup.methodWithoutArgs(), equals('oneline'));
     });
 
-    test("should use latest matching when definition", () {
-      when(mock.methodWithoutArgs()).thenReturn("A");
-      when(mock.methodWithoutArgs()).thenReturn("B");
-      expect(mock.methodWithoutArgs(), equals("B"));
+    test('should use latest matching when definition', () {
+      when(mock.methodWithoutArgs()).thenReturn('A');
+      when(mock.methodWithoutArgs()).thenReturn('B');
+      expect(mock.methodWithoutArgs(), equals('B'));
     });
 
-    test("should mock method with calculated result", () {
-      when(mock.methodWithNormalArgs(argThat(equals(43)))).thenReturn("43");
-      when(mock.methodWithNormalArgs(argThat(equals(42)))).thenReturn("42");
-      expect(mock.methodWithNormalArgs(43), equals("43"));
+    test('should mock method with calculated result', () {
+      when(mock.methodWithNormalArgs(argThat(equals(43)))).thenReturn('43');
+      when(mock.methodWithNormalArgs(argThat(equals(42)))).thenReturn('42');
+      expect(mock.methodWithNormalArgs(43), equals('43'));
     });
 
     // Error path tests.
-    test("should throw if `when` is called while stubbing", () {
+    test('should throw if `when` is called while stubbing', () {
       expect(() {
         var responseHelper = () {
           var mock2 = _MockedClass();
-          when(mock2.getter).thenReturn("A");
+          when(mock2.getter).thenReturn('A');
           return mock2;
         };
         when(mock.innerObj).thenReturn(responseHelper());
       }, throwsStateError);
     });
 
-    test("thenReturn throws if provided Future", () {
+    test('thenReturn throws if provided Future', () {
       expect(
           () => when(mock.methodReturningFuture())
-              .thenReturn(Future.value("stub")),
+              .thenReturn(Future.value('stub')),
           throwsArgumentError);
     });
 
-    test("thenReturn throws if provided Stream", () {
+    test('thenReturn throws if provided Stream', () {
       expect(
           () => when(mock.methodReturningStream())
-              .thenReturn(Stream.fromIterable(["stub"])),
+              .thenReturn(Stream.fromIterable(['stub'])),
           throwsArgumentError);
     });
 
-    test("thenAnswer supports stubbing method returning a Future", () async {
+    test('thenAnswer supports stubbing method returning a Future', () async {
       when(mock.methodReturningFuture())
-          .thenAnswer((_) => Future.value("stub"));
+          .thenAnswer((_) => Future.value('stub'));
 
-      expect(await mock.methodReturningFuture(), "stub");
+      expect(await mock.methodReturningFuture(), 'stub');
     });
 
-    test("thenAnswer supports stubbing method returning a Stream", () async {
+    test('thenAnswer supports stubbing method returning a Stream', () async {
       when(mock.methodReturningStream())
-          .thenAnswer((_) => Stream.fromIterable(["stub"]));
+          .thenAnswer((_) => Stream.fromIterable(['stub']));
 
-      expect(await mock.methodReturningStream().toList(), ["stub"]);
+      expect(await mock.methodReturningStream().toList(), ['stub']);
     });
 
-    test("should throw if named matcher is passed as the wrong name", () {
+    test('should throw if named matcher is passed as the wrong name', () {
       expect(() {
-        when(mock.methodWithNamedArgs(argThat(equals(42)), y: anyNamed("z")))
-            .thenReturn("99");
+        when(mock.methodWithNamedArgs(argThat(equals(42)), y: anyNamed('z')))
+            .thenReturn('99');
       }, throwsArgumentError);
     });
 
-    test("should throw if attempting to stub a real method", () {
+    test('should throw if attempting to stub a real method', () {
       var foo = _MockFoo();
       expect(() {
-        when(foo.quux()).thenReturn("Stub");
+        when(foo.quux()).thenReturn('Stub');
       }, throwsStateError);
     });
   });
 
-  group("throwOnMissingStub", () {
-    test("should throw when a mock was called without a matching stub", () {
+  group('throwOnMissingStub', () {
+    test('should throw when a mock was called without a matching stub', () {
       throwOnMissingStub(mock);
-      when(mock.methodWithNormalArgs(42)).thenReturn("Ultimate Answer");
+      when(mock.methodWithNormalArgs(42)).thenReturn('Ultimate Answer');
       expect(
         () => (mock).methodWithoutArgs(),
         throwsNoSuchMethodError,
       );
     });
 
-    test("should not throw when a mock was called with a matching stub", () {
+    test('should not throw when a mock was called with a matching stub', () {
       throwOnMissingStub(mock);
-      when(mock.methodWithoutArgs()).thenReturn("A");
+      when(mock.methodWithoutArgs()).thenReturn('A');
       expect(() => mock.methodWithoutArgs(), returnsNormally);
     });
   });
 
   test(
-      "reports an error when using an argument matcher outside of stubbing or "
-      "verification", () {
+      'reports an error when using an argument matcher outside of stubbing or '
+      'verification', () {
     expect(() => mock.methodWithNormalArgs(any), throwsArgumentError);
   });
 
   test(
-      "reports an error when using an argument matcher in a position other "
-      "than an argument for the stubbed method", () {
+      'reports an error when using an argument matcher in a position other '
+      'than an argument for the stubbed method', () {
     expect(() => when(mock.methodWithListArgs(List.filled(7, any))),
         throwsArgumentError);
   });

--- a/test/until_called_test.dart
+++ b/test/until_called_test.dart
@@ -81,8 +81,7 @@ void main() {
   });
 
   group('untilCalled', () {
-    StreamController<CallMethodsEvent> streamController =
-        StreamController.broadcast();
+    var streamController = StreamController<CallMethodsEvent>.broadcast();
 
     group('on methods already called', () {
       test('waits for method without args', () async {

--- a/test/verify_test.dart
+++ b/test/verify_test.dart
@@ -54,7 +54,7 @@ class LongToString {
 
 class _MockedClass extends Mock implements _RealClass {}
 
-void expectFail(Pattern expectedMessage, dynamic expectedToFail()) {
+void expectFail(Pattern expectedMessage, void Function() expectedToFail) {
   try {
     expectedToFail();
     fail('It was expected to fail!');


### PR DESCRIPTION
- omit_local_variable_types
- prefer_conditional_assignment
- prefer_if_null_operators
- prefer_single_quotes
- use_function_type_syntax_for_parameters

Also ignore a deprecated import.

Change a check against null to the string "null" to use string
interpolation which already handles `null`.

Remove some inferrable argument types on function literals.