### PR TITLE
Update README.md example to use Invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ expect(() => cat.lives, throwsRangeError);
 
 // We can calculate a response at call time.
 var responses = ["Purr", "Meow"];
-when(cat.sound()).thenAnswer((Invocation invocation) => responses.removeAt(0));
+when(cat.sound()).thenAnswer((_) => responses.removeAt(0));
 expect(cat.sound(), "Purr");
 expect(cat.sound(), "Meow");
 ```

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ expect(() => cat.lives, throwsRangeError);
 
 // We can calculate a response at call time.
 var responses = ["Purr", "Meow"];
-when(cat.sound()).thenAnswer(() => responses.removeAt(0));
+when(cat.sound()).thenAnswer((Invocation invocation) => responses.removeAt(0));
 expect(cat.sound(), "Purr");
 expect(cat.sound(), "Meow");
 ```


### PR DESCRIPTION
The following code snippet (as proposed currently in the README) fails:
```
      when(mock.field).thenAnswer(() => boolValue
          ? entryA
          : entryB);
```
`The argument type 'Entry Function()' can't be assigned to the parameter type 'Entry Function(Invocation)`

Adding an `Invocation` parameter makes the code snippet work.
```
      when(mock.field).thenAnswer((Invocation invocation) => boolValue
          ? entryA
          : entryB);
```