### PR TITLE
Add any matcher example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ when(cat.walk(["roof","tree"])).thenReturn(2);
 
 // ... or matchers
 when(cat.eatFood(argThat(startsWith("dry")))).thenReturn(false);
+when(cat.eatFood(any)).thenReturn(false);
 
 // ... or mix aguments with matchers
 when(cat.eatFood(argThat(startsWith("dry")), hungry: true)).thenReturn(true);


### PR DESCRIPTION
The other matchers shown here are functions but `any` is not. This may cause users to assume all matchers are functions and try calling `any()`.