### PR TITLE
Fix typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ verify(cat.lives=9);
 If an argument other than an ArgMatcher (like [`any`], [`anyNamed`],
 [`argThat`], [`captureThat`], etc.) is passed to a mock method, then the
 [`equals`] matcher is used for argument matching. If you need more strict
-matching consider use `argThat(identical(arg))`.
+matching consider use `argThat(same(arg))`.
 
 However, note that `null` cannot be used as an argument adjacent to ArgMatcher
 arguments, nor as an un-wrapped value passed as a named argument. For example:


### PR DESCRIPTION
`identical` is a boolean function, not a matcher. The matcher version is `same`.

- https://api.flutter.dev/flutter/dart-core/identical.html
- https://api.flutter.dev/flutter/package-matcher_matcher/same.html