### PR TITLE
Fix analyzer failures in example/iss

### DIFF
--- a/example/iss/pubspec.yaml
+++ b/example/iss/pubspec.yaml
@@ -1,0 +1,15 @@
+name: iss
+description: This library accesses the International Space Station's APIs (using [package:http](https://pub.dev/packages/http)) to fetch the space station's current location.
+
+publish_to: none
+
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
+dependencies:
+  http:
+
+dev_dependencies:
+  mockito:
+    path: ../../
+  test: ^1.5.1

--- a/example/iss/pubspec.yaml
+++ b/example/iss/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
-  http:
+  http: ^0.12.2
 
 dev_dependencies:
   mockito:


### PR DESCRIPTION
- add `pubspec.yaml` to `example` which defines `http` dependency