### PR TITLE
fix typo on verifyInOrder documentation

### DIFF
--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -928,7 +928,7 @@ Verification _makeVerify(bool never) {
 /// verifyInOrder([cat.eatFood("Milk"), cat.sound(), cat.eatFood(any)]);
 /// ```
 ///
-/// This verifies that `eatFood` was called with `"Milk"`, sound` was called
+/// This verifies that `eatFood` was called with `"Milk"`, `sound` was called
 /// with no arguments, and `eatFood` was then called with some argument.
 ///
 /// Note: [verifyInOrder] only verifies that each call was made in the order


### PR DESCRIPTION
There was a missing backtick on verifyInOrder documentation