### PR TITLE
Add verification before execute verifyInOrder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * `verifyInOrder` now returns a `List<VerificationResult>` which stores
   arguments which were captured in a call to `verifiyInOrder`.
 * **Breaking change:** Remove the public constructor for `VerificationResult`.
+* Doesn't allow `verify` been used inside the `verifyInOrder`.
 
 ## 5.0.0-nullsafety.7
 

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -992,7 +992,10 @@ _InOrderVerification get verifyInOrder {
     throw StateError(_verifyCalls.join());
   }
   _verificationInProgress = true;
-  return <T>(List<T> _) {
+  return <T>(List<T> verifyOrderCalls) {
+    if (verifyOrderCalls.whereType<VerificationResult>().isNotEmpty) {
+      fail('verifyInOrder was called with a verify argument(s)');
+    }
     _verificationInProgress = false;
     var verificationResults = <VerificationResult>[];
     var time = DateTime.fromMillisecondsSinceEpoch(0);

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -939,6 +939,10 @@ Verification _makeVerify(bool never) {
     }
     throw StateError(message);
   }
+  if (_verificationInProgress) {
+    fail('There is already a verification in progress, '
+        'check if it was not called with a verify argument(s)');
+  }
   _verificationInProgress = true;
   return <T>(T mock) {
     _verificationInProgress = false;
@@ -992,10 +996,7 @@ _InOrderVerification get verifyInOrder {
     throw StateError(_verifyCalls.join());
   }
   _verificationInProgress = true;
-  return <T>(List<T> verifyOrderCalls) {
-    if (verifyOrderCalls.whereType<VerificationResult>().isNotEmpty) {
-      fail('verifyInOrder was called with a verify argument(s)');
-    }
+  return <T>(List<T> _) {
     _verificationInProgress = false;
     var verificationResults = <VerificationResult>[];
     var time = DateTime.fromMillisecondsSinceEpoch(0);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
-  analyzer: '>=0.39.15 <0.42.0'
+  analyzer: '>=0.39.15 <2.0.0'
   build: ^1.3.0
   code_builder: ^3.4.0
   collection: ^1.15.0-nullsafety.5
@@ -27,3 +27,10 @@ dev_dependencies:
   package_config: '>=1.9.3 <3.0.0'
   pedantic: ^1.10.0-nullsafety
   test: ^1.16.0-nullsafety.12
+
+# Force analyzer 1.0.0 during development and CI, so that test expectations work perfectly.
+# This is necessary as analyze 1.0.0 is not in the version constraints of some other dependencies.
+# glob also gets into the mix.
+dependency_overrides:
+  analyzer: ^1.0.0
+  glob: ^1.1.0

--- a/test/verify_test.dart
+++ b/test/verify_test.dart
@@ -466,6 +466,18 @@ void main() {
       });
     });
 
+    test('verify been used as an argument fails', () {
+      mock.methodWithoutArgs();
+      mock.getter;
+      expectFail(
+          'verifyInOrder was called with a verify argument(s)', () {
+        verifyInOrder([
+          verify(mock.getter),
+          verify(mock.methodWithoutArgs())
+        ]);
+      });
+    });
+
     test('methods can be called again and again', () {
       mock.methodWithoutArgs();
       mock.getter;

--- a/test/verify_test.dart
+++ b/test/verify_test.dart
@@ -470,10 +470,11 @@ void main() {
       mock.methodWithoutArgs();
       mock.getter;
       expectFail(
-          'verifyInOrder was called with a verify argument(s)', () {
+          'There is already a verification in progress, '
+          'check if it was not called with a verify argument(s)', () {
         verifyInOrder([
           verify(mock.getter),
-          verify(mock.methodWithoutArgs())
+          verify(mock.methodWithoutArgs()),
         ]);
       });
     });


### PR DESCRIPTION
This PR is adding a verification that will handle the issue: https://github.com/dart-lang/mockito/issues/262.
The idea's to prevent the `verifyInOrder` has `VerifyCall` as an argument.