### PR TITLE
update to the upcoming test_api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.1-dev
+
+* Update to the latest test_api.
+
 ## 5.0.0
 
 * `verifyInOrder` now returns a `List<VerificationResult>` which stores

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 5.0.0
+version: 5.0.1-dev
 
 description: A mock framework inspired by Mockito.
 homepage: https://github.com/dart-lang/mockito
@@ -17,7 +17,7 @@ dependencies:
   meta: ^1.3.0
   path: ^1.8.0
   source_gen: ^0.9.6
-  test_api: ^0.2.19
+  test_api: ^0.3.0
 
 dev_dependencies:
   build_runner: ^1.0.0
@@ -27,3 +27,9 @@ dev_dependencies:
   package_config: '>=1.9.3 <3.0.0'
   pedantic: ^1.10.0
   test: ^1.16.0
+
+dependency_overrides:
+  test_api:
+    git:
+      url: https://github.com/dart-lang/test.git
+      path: pkgs/test_api

--- a/test/invocation_matcher_test.dart
+++ b/test/invocation_matcher_test.dart
@@ -173,7 +173,7 @@ void shouldFail(value, Matcher matcher, expected) {
         : expected is RegExp
             ? contains(expected)
             : expected;
-    expect(collapseWhitespace(e.message), matcher, reason: reason);
+    expect(collapseWhitespace(e.message!), matcher, reason: reason);
   }
 }
 


### PR DESCRIPTION
This needs to be updated prior to publishing test_api so we can roll internally and test that version, then we can publish and remove the override here.