### PR TITLE
Expand test_api dep to allow test_api 0.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.1+1
+
+* Allow test\_api 0.3.x.
+
 ## 4.1.1
 
 * Mark the unexported and accidentally public `setDefaultResponse` as

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 4.1.1
+version: 4.1.1+1
 
 authors:
   - Dmitriy Fibulwinter <fibulwinter@gmail.com>
@@ -15,7 +15,7 @@ dependencies:
   collection: ^1.1.0
   matcher: ^0.12.3
   meta: ^1.0.4
-  test_api: ^0.2.1
+  test_api: '>=0.2.1 <0.4.0'
 
 dev_dependencies:
   build_runner: ^1.0.0


### PR DESCRIPTION
This is a patch release for mockito 4.1.1.

Fixes #352 