### PR TITLE
Support latest build packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.2-dev
+
+* Support the latest build packages
+
 ## 5.0.1
 
 * Update to the latest test_api.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 5.0.1
+version: 5.0.2-dev
 
 description: A mock framework inspired by Mockito.
 homepage: https://github.com/dart-lang/mockito
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   analyzer: ^1.0.0
-  build: ^1.3.0
+  build: '>=1.3.0 <3.0.0'
   code_builder: ^3.7.0
   collection: ^1.15.0
   dart_style: ^1.3.6
@@ -20,8 +20,8 @@ dependencies:
   test_api: '>=0.2.1 <0.4.0'
 
 dev_dependencies:
-  build_runner: ^1.0.0
-  build_test: ^1.1.0
+  build_runner: ^1.12.0
+  build_test: ^2.0.0
   build_web_compilers: '>=1.0.0 <3.0.0'
   http: ^0.13.0
   package_config: '>=1.9.3 <3.0.0'


### PR DESCRIPTION
I raised the `build` dependency to support version 2.x. It looks like we're not using `AssetId.resolve` anywhere, so we don't need to use 2.x as a lower bound.

Closes #363