### PR TITLE
Support version 2 of dart_style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 5.0.2-dev
 
 * Support the latest build packages
+* Support the latest version of `dart_style`
 
 ## 5.0.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   build: '>=1.3.0 <3.0.0'
   code_builder: ^3.7.0
   collection: ^1.15.0
-  dart_style: ^1.3.6
+  dart_style: '>1.3.6 <3.0.0'
   matcher: ^0.12.10
   meta: ^1.3.0
   path: ^1.8.0


### PR DESCRIPTION
Increase the upper bound of the `dart_style` dependency to support versions 2.x.

To test this, I manually added a 

```yaml
dependency_overrides:
  dart_style: ^2.0.0
```

All tests and analysis still pass with that override, so I'm pretty confident that we're not affected by any breaking change (the changelog doesn't list any).