### PR TITLE
Make verifyInOrder fail given non-mock-calls.

### DIFF
--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -997,7 +997,10 @@ _InOrderVerification get verifyInOrder {
     throw StateError(_verifyCalls.join());
   }
   _verificationInProgress = true;
-  return <T>(List<T> _) {
+  return <T>(List<T> responses) {
+    if (responses.length != _verifyCalls.length) {
+      fail('Used on a non-mockito object');
+    }
     _verificationInProgress = false;
     var verificationResults = <VerificationResult>[];
     var time = DateTime.fromMillisecondsSinceEpoch(0);

--- a/test/verify_test.dart
+++ b/test/verify_test.dart
@@ -206,6 +206,12 @@ void main() {
                     '2 verify calls have been stored.')));
       }
     });
+
+    test('should fail when called with non-mock-call parameter', () {
+      expectFail('Used on a non-mockito object', () {
+        verifyInOrder(['a string is not a mock call']);
+      });
+    });
   });
 
   group('verify should fail when no matching call is found', () {
@@ -454,6 +460,12 @@ void main() {
           'Matching call #1 not found. All calls: '
           '_MockedClass.methodWithoutArgs(), _MockedClass.getter', () {
         verifyInOrder([mock.getter, mock.methodWithoutArgs()]);
+      });
+    });
+
+    test('should fail when given non-mock-call parameters', () {
+      expectFail('Used on a non-mockito object', () {
+        verifyInOrder(['a string is not a mock call']);
       });
     });
 


### PR DESCRIPTION
Also adds a test for verify failing when given a non-mock call, which is currently untested.

Without this change, this mistake is possible and horrific:

```dart
verifyInOrder([
  fakeService.someCall(),
  fakeService.someOtherCall(),
]);
```

Which just always passes (assuming those calls don't throw), as does e.g. `verifyInOrder(['banana']);`