### PR TITLE
Follow Dart file conventions | Add more detail to the description fie…

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mockito
 version: 5.0.9
 
-description: A mock framework inspired by Mockito.
+description: A mock framework inspired by Mockito.  With APIs for Fakes, Mocks, behavior verification, stubbing, and much more.
 homepage: https://github.com/dart-lang/mockito
 
 environment:


### PR DESCRIPTION
Follow Dart file conventions 

Add more detail to the description file description of pubspec.yaml. 
Use 60 to 180 characters to describe the package, what it does, and its target use case.