### PR TITLE
Ignore lints unnecessary_overrides in generated code

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -84,6 +84,7 @@ class MockBuilder implements Builder {
       b.body.add(Code(
           '// ignore_for_file: invalid_use_of_visible_for_testing_member\n'));
       b.body.add(Code('// ignore_for_file: prefer_const_constructors\n'));
+      b.body.add(Code('// ignore_for_file: unnecessary_overrides\n'));
       // The code_builder `asA` API unconditionally adds defensive parentheses.
       b.body.add(Code('// ignore_for_file: unnecessary_parenthesis\n\n'));
       b.body.addAll(mockLibraryInfo.fakeClasses);


### PR DESCRIPTION
With mockito `v5.0.10` and the commit [Override toString implementation on generated Fakes](https://github.com/dart-lang/mockito/commit/fd5f6039518599bc6050fdf5f1126b2c2bcb314e), the generated code produces a `unnecessary_overrides` lint (from lints/core.yaml)