### PR TITLE
fix(linter): ignore some linters triggered by generated files

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -98,6 +98,7 @@ class MockBuilder implements Builder {
       b.body.add(Code('// ignore_for_file: camel_case_types\n'));
       b.body.add(Code('// ignore_for_file: always_specify_types\n'));
       b.body.add(Code('// ignore_for_file: unnecessary_overrides\n'));
+      b.body.add(Code('// ignore_for_file: implementation_imports\n'));
       b.body.add(Code('// ignore_for_file: avoid_implementing_value_types\n\n'));
       b.body.addAll(mockLibraryInfo.fakeClasses);
       b.body.addAll(mockLibraryInfo.mockClasses);

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -95,9 +95,9 @@ class MockBuilder implements Builder {
       // The code_builder `asA` API unconditionally adds defensive parentheses.
       b.body.add(Code('// ignore_for_file: unnecessary_parenthesis\n'));
       // The generator appends a suffix to fake classes
-      b.body.add(Code('// ignore_for_file: camel_case_types\n\n'));
-      b.body.add(Code('// ignore_for_file: always_specify_types\n\n'));
-      b.body.add(Code('// ignore_for_file: unnecessary_overrides\n\n'));
+      b.body.add(Code('// ignore_for_file: camel_case_types\n'));
+      b.body.add(Code('// ignore_for_file: always_specify_types\n'));
+      b.body.add(Code('// ignore_for_file: unnecessary_overrides\n'));
       b.body.add(Code('// ignore_for_file: avoid_implementing_value_types\n\n'));
       b.body.addAll(mockLibraryInfo.fakeClasses);
       b.body.addAll(mockLibraryInfo.mockClasses);

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -96,6 +96,9 @@ class MockBuilder implements Builder {
       b.body.add(Code('// ignore_for_file: unnecessary_parenthesis\n'));
       // The generator appends a suffix to fake classes
       b.body.add(Code('// ignore_for_file: camel_case_types\n\n'));
+      b.body.add(Code('// ignore_for_file: always_specify_types\n\n'));
+      b.body.add(Code('// ignore_for_file: unnecessary_overrides\n\n'));
+      b.body.add(Code('// ignore_for_file: avoid_implementing_value_types\n\n'));
       b.body.addAll(mockLibraryInfo.fakeClasses);
       b.body.addAll(mockLibraryInfo.mockClasses);
     });

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -98,7 +98,6 @@ class MockBuilder implements Builder {
       b.body.add(Code('// ignore_for_file: camel_case_types\n'));
       b.body.add(Code('// ignore_for_file: always_specify_types\n'));
       b.body.add(Code('// ignore_for_file: unnecessary_overrides\n'));
-      b.body.add(Code('// ignore_for_file: implementation_imports\n'));
       b.body.add(Code('// ignore_for_file: avoid_implementing_value_types\n\n'));
       b.body.addAll(mockLibraryInfo.fakeClasses);
       b.body.addAll(mockLibraryInfo.mockClasses);


### PR DESCRIPTION
Some generated code is triggering some linters making pipelines with this linters to fail.
Generated files should not trigger any linter.

![image](https://user-images.githubusercontent.com/37809501/134570191-b1510e57-fe44-4789-9a90-cdc97f01f823.png)
