### PR TITLE
Add ignore all lints comment to generated code

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -81,9 +81,10 @@ class MockBuilder implements Builder {
 
     final mockLibrary = Library((b) {
       // These comments are added after import directives; leading newlines
-      // are necessary.
-      b.body.add(
-          Code('\n\n// ignore_for_file: avoid_redundant_argument_values\n'));
+      // are necessary. Individual rules are still ignored to preserve backwards
+      // compatibility with older versions of Dart.
+      b.body.add(Code('\n\n// // ignore_for_file: type=lint\n'));
+      b.body.add(Code('// ignore_for_file: avoid_redundant_argument_values\n'));
       // We might generate a setter without a corresponding getter.
       b.body.add(Code('// ignore_for_file: avoid_setters_without_getters\n'));
       // We don't properly prefix imported class names in doc comments.

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -83,7 +83,7 @@ class MockBuilder implements Builder {
       // These comments are added after import directives; leading newlines
       // are necessary. Individual rules are still ignored to preserve backwards
       // compatibility with older versions of Dart.
-      b.body.add(Code('\n\n// // ignore_for_file: type=lint\n'));
+      b.body.add(Code('\n\n// ignore_for_file: type=lint\n'));
       b.body.add(Code('// ignore_for_file: avoid_redundant_argument_values\n'));
       // We might generate a setter without a corresponding getter.
       b.body.add(Code('// ignore_for_file: avoid_setters_without_getters\n'));


### PR DESCRIPTION
This PR introduces a trivial enhancement in the form of the new `ignore_for_file: type=lint` comment that was added in Dart 2.15. It ensures that dart analyzer will ignore the generated file without having to explicitly exclude it in a project's analysis_options.yaml. I'm not sure if any addition tests are needed for this change.

It is a follow-up from https://github.com/dart-lang/sdk/issues/47965.