### PR TITLE
fix: version number in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Mock library for Dart inspired by [Mockito](https://github.com/mockito/mockito).
 
 ## Let's create mocks
 
-Mockito 5.0.0 supports Dart's new **null safety** language feature in Dart 2.12,
+Mockito 5.1.0 supports Dart's new **null safety** language feature in Dart 2.12,
 primarily with code generation.
 
 To use Mockito's generated mock classes, add a `build_runner` dependency in your


### PR DESCRIPTION
Updated version number from 5.0.0 to 5.1.0 in [README.md](https://github.com/dart-lang/mockito#lets-create-mocks)