### PR TITLE
Fix closing parentheses being included in URL when Cmd+Clicking in iTerm2

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -699,7 +699,7 @@ class _MockTargetGatherer {
             '${enclosingElement.fullName} features a non-nullable unknown '
             'return type, and cannot be stubbed. Try generating this mock with '
             "a MockSpec with 'unsupportedMembers' or a dummy generator (see "
-            'https://pub.dev/documentation/mockito/latest/annotations/MockSpec-class.html).');
+            'https://pub.dev/documentation/mockito/latest/annotations/MockSpec-class.html ).');
       }
     }
 

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -234,7 +234,7 @@ class MissingStubError extends Error {
       "Add a stub for this method using Mockito's 'when' API, or generate the "
       '${receiver.runtimeType} mock with a MockSpec with '
       "'returnNullOnMissingStub: true' (see "
-      'https://pub.dev/documentation/mockito/latest/annotations/MockSpec-class.html).';
+      'https://pub.dev/documentation/mockito/latest/annotations/MockSpec-class.html ).';
 }
 
 typedef _ReturnsCannedResponse = CallPair<dynamic> Function();


### PR DESCRIPTION
First off, thanks for building mockito :) It just allowed me to get rid of a hand-written mock I really did not want to maintain anymore 😅

---

Cmd+Click in iTerm2 allows you to open a URL directly from the terminal. When
I ran into these error messages in Mockito, I was greeted with a 404 after opening
the URL. This was because iTerm2 was erroneously including the closing parenthesis
in the URL, which was quite hard to notice. As a workaround, adding a space after
the URL prevents this issue.

I realize this is not a perfect fix, but it took me quite a while to notice, and maybe it's worth the small "uglyness" of adding the space after the URL.

Tangentially related, after navigating to the docs manually, I found that the page in question did not help me _that_ much. I ended up finding the solution to my problem in the [null safety readme](https://github.com/dart-lang/mockito/blob/master/NULL_SAFETY_README.md). Would it perhaps make sense to include that in the error message, or link it from the documentation of `MockSpec`? 