### PR TITLE
bump version constraint of package:analyzer

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.17.0-0 <3.0.0'
 
 dependencies:
-  analyzer: '>=2.1.0 <5.0.0'
+  analyzer: '>=4.3.0 <5.0.0'
   build: '>=1.3.0 <3.0.0'
   code_builder: ^4.2.0
   collection: ^1.15.0


### PR DESCRIPTION
The [usage](https://github.com/dart-lang/mockito/blob/2acf22f4d400c6e1eee0f6ca595092220fba8b34/lib/src/builder.dart#L412) of the `libraryExports` property (of the `LibraryOrAugmentationElement` class which is implemented by `LibraryElement`) stipulates at least v4.3.0 of `package:analyzer`
- see https://github.com/dart-lang/sdk/commit/e23101a16fedf090127b52142ac96a6091d2f617#diff-4d31b9e465218793b506aee1f5156d6d80a86c26e6c480b33eb306f20817bdb5R1614 where `libraryExports` was added
- also see the changelog entry https://github.com/dart-lang/sdk/blob/main/pkg/analyzer/CHANGELOG.md#430