### PR TITLE
Bump analyzer to support 5.0.0 with mockito 5.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.3.2
+
+* Support analyzer 5.0.0.
+
 ## 5.3.1
 
 * Fix analyzer and code_builder dependencies.

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const packageVersion = '5.3.1';
+const packageVersion = '5.3.2';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 5.3.1
+version: 5.3.2
 description: >-
   A mock framework inspired by Mockito with APIs for Fakes, Mocks,
   behavior verification, and stubbing.
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.17.0-0 <3.0.0'
 
 dependencies:
-  analyzer: '>=4.6.0 <5.0.0'
+  analyzer: '>=4.7.0 <6.0.0'
   build: '>=1.3.0 <3.0.0'
   code_builder: ^4.3.0
   collection: ^1.15.0


### PR DESCRIPTION
I bumped the lower bound to 4.7.0 because I think that is where the last deprecations happened, so we support both of these versions pretty solidly. I tested both 4.7.0 and 5.0.0.