### PR TITLE
Add test case to reproduce issue with throwing on missing stub when a function returns a Future

### DIFF
--- a/test/end2end/foo.dart
+++ b/test/end2end/foo.dart
@@ -19,9 +19,6 @@ class Foo<T> {
   set setter(int? value) {}
   void returnsVoid() {}
   Future<void> returnsFutureVoid() => Future.value();
-  void returnsVoidWithJsonArg(Map<String, dynamic> x) => null;
-  Future<void> returnsFutureVoidWithJsonArg(Map<String, dynamic> x) =>
-      Future.value();
   Future<void>? returnsNullableFutureVoid() => Future.value();
   Bar returnsBar(int arg) => Bar();
 }

--- a/test/end2end/foo.dart
+++ b/test/end2end/foo.dart
@@ -19,6 +19,9 @@ class Foo<T> {
   set setter(int? value) {}
   void returnsVoid() {}
   Future<void> returnsFutureVoid() => Future.value();
+  void returnsVoidWithJsonArg(Map<String, dynamic> x) => null;
+  Future<void> returnsFutureVoidWithJsonArg(Map<String, dynamic> x) =>
+      Future.value();
   Future<void>? returnsNullableFutureVoid() => Future.value();
   Bar returnsBar(int arg) => Bar();
 }

--- a/test/end2end/generated_mocks_test.dart
+++ b/test/end2end/generated_mocks_test.dart
@@ -175,6 +175,33 @@ void main() {
       );
     });
 
+    test('an unstubbed method with a json parameter throws', () {
+      expect(
+        () => foo.returnsVoidWithJsonArg({'answer':  42}),
+        throwsA(TypeMatcher<MissingStubError>().having((e) => e.toString(),
+            'toString()', contains('returnsVoidWithJsonArg({answer: 42})'))),
+      );
+    });
+
+    test(
+        'an unstubbed method returning a future throws', () {
+      expect(
+        () => foo.returnsFutureVoid(),
+        throwsA(TypeMatcher<MissingStubError>().having((e) => e.toString(),
+            'toString()', contains('TODO'))),
+      );
+    });
+
+    test(
+        'an unstubbed method with a json parameter and returning a future '
+        'throws', () {
+      expect(
+        () => foo.returnsFutureVoidWithJsonArg({'answer':  42}),
+        throwsA(TypeMatcher<MissingStubError>().having((e) => e.toString(),
+            'toString()', contains('TODO'))),
+      );
+    });
+
     test('an unstubbed getter throws', () {
       expect(
         () => foo.getter,

--- a/test/end2end/generated_mocks_test.dart
+++ b/test/end2end/generated_mocks_test.dart
@@ -175,30 +175,12 @@ void main() {
       );
     });
 
-    test('an unstubbed method with a json parameter throws', () {
-      expect(
-        () => foo.returnsVoidWithJsonArg({'answer':  42}),
-        throwsA(TypeMatcher<MissingStubError>().having((e) => e.toString(),
-            'toString()', contains('returnsVoidWithJsonArg({answer: 42})'))),
-      );
-    });
-
     test(
         'an unstubbed method returning a future throws', () {
       expect(
         () => foo.returnsFutureVoid(),
         throwsA(TypeMatcher<MissingStubError>().having((e) => e.toString(),
-            'toString()', contains('TODO'))),
-      );
-    });
-
-    test(
-        'an unstubbed method with a json parameter and returning a future '
-        'throws', () {
-      expect(
-        () => foo.returnsFutureVoidWithJsonArg({'answer':  42}),
-        throwsA(TypeMatcher<MissingStubError>().having((e) => e.toString(),
-            'toString()', contains('TODO'))),
+            'toString()', contains('returnsFutureVoid()'))),
       );
     });
 


### PR DESCRIPTION
Relates to https://github.com/dart-lang/mockito/issues/581