### PR TITLE
support mocking non-nullable generic return types now. 

### DIFF
--- a/lib/mockito.dart
+++ b/lib/mockito.dart
@@ -53,6 +53,6 @@ export 'src/mock.dart'
         MissingStubError,
         FakeUsedError,
 
-        //to support non-nullable return types
+        // -- dummy instance creation
         defaultDummyValue,
         setDefaultDummyValue;

--- a/lib/mockito.dart
+++ b/lib/mockito.dart
@@ -51,4 +51,8 @@ export 'src/mock.dart'
         logInvocations,
         untilCalled,
         MissingStubError,
-        FakeUsedError;
+        FakeUsedError,
+
+        //to support non-nullable return types
+        defaultDummyValue,
+        setDefaultDummyValue;

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -821,9 +821,6 @@ class _MockTargetGatherer {
   /// A method is not valid for stubbing if:
   /// - It has a private type anywhere in its signature; Mockito cannot override
   ///   such a method.
-  /// - It has a non-nullable type variable return type, for example `T m<T>()`,
-  ///   and no corresponding dummy generator. Mockito cannot generate its own
-  ///   dummy return values for unknown types.
   void _checkMethodsToStubAreValid(_MockTarget mockTarget) {
     final interfaceElement = mockTarget.interfaceElement;
     final className = interfaceElement.name;
@@ -910,16 +907,6 @@ class _MockTargetGatherer {
       errorMessages.addAll(_checkFunction(returnType, enclosingElement,
           allowUnsupportedMember: allowUnsupportedMember,
           hasDummyGenerator: hasDummyGenerator));
-    } else if (returnType is analyzer.TypeParameterType) {
-      if (!isParameter &&
-          !allowUnsupportedMember &&
-          !hasDummyGenerator &&
-          _entryLib.typeSystem.isPotentiallyNonNullable(returnType)) {
-        errorMessages
-            .add('${enclosingElement.fullName} features a non-nullable unknown '
-                'return type, and cannot be stubbed. '
-                '$_tryUnsupportedMembersMessage');
-      }
     }
 
     for (var parameter in function.parameters) {
@@ -1365,16 +1352,11 @@ class _MockClassInfo {
       return;
     }
 
-    final returnTypeIsTypeVariable =
-        typeSystem.isPotentiallyNonNullable(returnType) &&
-            returnType is analyzer.TypeParameterType;
     final fallbackGenerator = fallbackGenerators[method.name];
     final parametersContainPrivateName =
         method.parameters.any((p) => p.type.containsPrivateName);
     final throwsUnsupported = fallbackGenerator == null &&
-        (returnTypeIsTypeVariable ||
-            returnType.containsPrivateName ||
-            parametersContainPrivateName);
+        (returnType.containsPrivateName || parametersContainPrivateName);
 
     if (throwsUnsupported) {
       if (!mockTarget.unsupportedMembers.contains(name)) {
@@ -1382,8 +1364,7 @@ class _MockClassInfo {
         // [_MockTargetGatherer._checkFunction].
         throw InvalidMockitoAnnotationException(
             "Mockito cannot generate a valid override for '$name', as it has a "
-            'non-nullable unknown return type or a private type in its '
-            'signature.');
+            'private type in its signature.');
       }
       builder.body = refer('UnsupportedError')
           .call([
@@ -1467,6 +1448,12 @@ class _MockClassInfo {
     }
 
     if (type is! analyzer.InterfaceType) {
+      if (type is analyzer.TypeParameterType) {
+        return referImported(
+                'defaultDummyValue<$type>', 'package:mockito/mockito.dart')
+            .call([]);
+      }
+
       // TODO(srawlins): This case is not known.
       return literalNull;
     }
@@ -1482,22 +1469,13 @@ class _MockClassInfo {
       final typeArgument = typeArguments.first;
       final typeArgumentIsPotentiallyNonNullable =
           typeSystem.isPotentiallyNonNullable(typeArgument);
-      if (typeArgument is analyzer.TypeParameterType &&
-          typeArgumentIsPotentiallyNonNullable) {
-        // We cannot create a valid Future for this unknown, potentially
-        // non-nullable type, so we'll use a `_FakeFuture`, which will throw
-        // if awaited.
-        var futureType = typeProvider.futureType(typeArguments.first);
-        return _dummyValueImplementing(futureType, invocation);
-      } else {
-        // Create a real Future with a legal value, via [Future.value].
-        final futureValueArguments = typeArgumentIsPotentiallyNonNullable
-            ? [_dummyValue(typeArgument, invocation)]
-            : <Expression>[];
-        return _futureReference(_typeReference(typeArgument))
-            .property('value')
-            .call(futureValueArguments);
-      }
+      // Create a real Future with a legal value, via [Future.value].
+      final futureValueArguments = typeArgumentIsPotentiallyNonNullable
+          ? [_dummyValue(typeArgument, invocation)]
+          : <Expression>[];
+      return _futureReference(_typeReference(typeArgument))
+          .property('value')
+          .call(futureValueArguments);
     } else if (type.isDartCoreInt) {
       return literalNum(0);
     } else if (type.isDartCoreIterable || type.isDartCoreList) {
@@ -1866,18 +1844,15 @@ class _MockClassInfo {
 
     final returnType = getter.returnType;
     final fallbackGenerator = fallbackGenerators[getter.name];
-    final returnTypeIsTypeVariable =
-        typeSystem.isPotentiallyNonNullable(returnType) &&
-            returnType is analyzer.TypeParameterType;
-    final throwsUnsupported = fallbackGenerator == null &&
-        (returnTypeIsTypeVariable || getter.returnType.containsPrivateName);
+    final throwsUnsupported =
+        fallbackGenerator == null && getter.returnType.containsPrivateName;
     if (throwsUnsupported) {
       if (!mockTarget.unsupportedMembers.contains(getter.name)) {
         // We shouldn't get here as this is guarded against in
         // [_MockTargetGatherer._checkFunction].
         throw InvalidMockitoAnnotationException(
             "Mockito cannot generate a valid override for '${getter.name}', as "
-            'it has a non-nullable unknown type or a private type.');
+            'it has a private type.');
       }
       builder.body = refer('UnsupportedError')
           .call([

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -1268,7 +1268,7 @@ extension ListOfVerificationResult on List<VerificationResult> {
   List<List<dynamic>> get captured => [...map((result) => result.captured)];
 }
 
-final _defaultDummyValueFor = <Type, dynamic>{
+final _defaultDummyValueFor = <Type, Object?>{
   num: 0,
   int: 0,
   double: 0.0,

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -1267,3 +1267,27 @@ extension ListOfVerificationResult on List<VerificationResult> {
   /// [verifyInOrder].
   List<List<dynamic>> get captured => [...map((result) => result.captured)];
 }
+
+final _defaultDummyValueFor = <Type, dynamic>{
+  num: 0,
+  int: 0,
+  double: 0.0,
+  bool: false,
+  String: '',
+};
+
+void setDefaultDummyValue<T>(T value) {
+  _defaultDummyValueFor[T] = value;
+}
+
+T defaultDummyValue<T>() {
+  if (null is T) {
+    return null as T;
+  }
+  if (_defaultDummyValueFor.containsKey(T)) {
+    return _defaultDummyValueFor[T] as T;
+  } else {
+    throw UnsupportedError('No default dummy value specified for $T, '
+        'call setDefaultDummyValue<$T>(value) to set one');
+  }
+}

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -1287,7 +1287,7 @@ T defaultDummyValue<T>() {
   if (_defaultDummyValueFor.containsKey(T)) {
     return _defaultDummyValueFor[T] as T;
   } else {
-    throw UnsupportedError('No default dummy value specified for $T, '
-        'call setDefaultDummyValue<$T>(value) to set one');
+    throw UnsupportedError("No default dummy value specified for '$T', "
+        'call `setDefaultDummyValue<$T>(value)` to set one');
   }
 }

--- a/test/builder/auto_mocks_test.dart
+++ b/test/builder/auto_mocks_test.dart
@@ -3050,7 +3050,7 @@ void main() {
   });
 
   test(
-      'uses defaultDummyValue, given a a class with a method with a '
+      'uses defaultDummyValue, given a class with a method with a '
       'non-nullable class-declared type variable return type', () async {
     await expectSingleNonNullableOutput(
       dedent('''

--- a/test/builder/auto_mocks_test.dart
+++ b/test/builder/auto_mocks_test.dart
@@ -1576,7 +1576,7 @@ void main() {
           FutureOr<R> m<R>();
         }
         '''),
-      _containsAllOf('_i2.FutureOr<R> m<R>() => (super.noSuchMethod('),
+      _containsAllOf('_i3.FutureOr<R> m<R>() => (super.noSuchMethod('),
     );
   });
 
@@ -2310,7 +2310,7 @@ void main() {
         Future<T> m<T>() async => false;
       }
       '''),
-      _containsAllOf('returnValue: _FakeFuture_0<T>('),
+      _containsAllOf('returnValue: _i3.Future<T>.value(_i1.defaultDummyValue'),
     );
   });
 
@@ -3037,79 +3037,55 @@ void main() {
   });
 
   test(
-      'throws when GenerateMocks is given a class with a getter with a '
-      'non-nullable class-declared type variable type', () async {
-    _expectBuilderThrows(
-      assets: {
-        ...annotationsAsset,
-        ...simpleTestAsset,
-        'foo|lib/foo.dart': dedent('''
+      'GenerateMocks works given class with a getter with a non-nullable '
+      'class-declared type variable type', () async {
+    await expectSingleNonNullableOutput(
+      dedent('''
         abstract class Foo<T> {
           T get f;
         }
         '''),
-      },
-      message: contains(
-          "The property accessor 'Foo.f' features a non-nullable unknown "
-          'return type, and cannot be stubbed'),
+      _containsAllOf('returnValue: _i1.defaultDummyValue<T>()'),
     );
   });
 
   test(
-      'throws when GenerateMocks is given a class with a method with a '
+      'GenerateMocks works given a class with a method with a '
       'non-nullable class-declared type variable return type', () async {
-    _expectBuilderThrows(
-      assets: {
-        ...annotationsAsset,
-        ...simpleTestAsset,
-        'foo|lib/foo.dart': dedent('''
+    await expectSingleNonNullableOutput(
+      dedent('''
         abstract class Foo<T> {
           T m(int a);
         }
         '''),
-      },
-      message: contains(
-          "The method 'Foo.m' features a non-nullable unknown return type, and "
-          'cannot be stubbed'),
+      _containsAllOf('returnValue: _i1.defaultDummyValue<T>()'),
     );
   });
 
   test(
-      'throws when GenerateMocks is given a class with a method with a '
+      'GenerateMocks works given a class with a method with a '
       'non-nullable method-declared type variable return type', () async {
-    _expectBuilderThrows(
-      assets: {
-        ...annotationsAsset,
-        ...simpleTestAsset,
-        'foo|lib/foo.dart': dedent('''
+    await expectSingleNonNullableOutput(
+      dedent('''
         abstract class Foo {
           T m<T>(int a);
         }
         '''),
-      },
-      message: contains(
-          "The method 'Foo.m' features a non-nullable unknown return type, and "
-          'cannot be stubbed'),
+      _containsAllOf('returnValue: _i1.defaultDummyValue<T>()'),
     );
   });
 
   test(
-      'throws when GenerateMocks is given a class with a method with a '
+      'GenerateMocks works given a class with a method with a '
       'non-nullable method-declared bounded type variable return type',
       () async {
-    _expectBuilderThrows(
-      assets: {
-        ...annotationsAsset,
-        ...simpleTestAsset,
-        'foo|lib/foo.dart': dedent('''
+    await expectSingleNonNullableOutput(
+      dedent('''
         abstract class Foo {
           T m<T extends num>(int a);
         }
         '''),
-      },
-      message: contains(
-          "The method 'Foo.m' features a non-nullable unknown return type, and "
-          'cannot be stubbed'),
+      _containsAllOf('returnValue: _i1.defaultDummyValue<T>()'),
     );
   });
 

--- a/test/builder/auto_mocks_test.dart
+++ b/test/builder/auto_mocks_test.dart
@@ -3037,7 +3037,7 @@ void main() {
   });
 
   test(
-      'GenerateMocks works given class with a getter with a non-nullable '
+      'uses defaultDummyValue, given a class with a getter with a non-nullable '
       'class-declared type variable type', () async {
     await expectSingleNonNullableOutput(
       dedent('''
@@ -3050,7 +3050,7 @@ void main() {
   });
 
   test(
-      'GenerateMocks works given a class with a method with a '
+      'uses defaultDummyValue, given a a class with a method with a '
       'non-nullable class-declared type variable return type', () async {
     await expectSingleNonNullableOutput(
       dedent('''
@@ -3063,7 +3063,7 @@ void main() {
   });
 
   test(
-      'GenerateMocks works given a class with a method with a '
+      'uses defaultDummyValue, given a class with a method with a '
       'non-nullable method-declared type variable return type', () async {
     await expectSingleNonNullableOutput(
       dedent('''
@@ -3076,7 +3076,7 @@ void main() {
   });
 
   test(
-      'GenerateMocks works given a class with a method with a '
+      'uses defaultDummyValue, given a class with a method with a '
       'non-nullable method-declared bounded type variable return type',
       () async {
     await expectSingleNonNullableOutput(

--- a/test/builder/custom_mocks_test.dart
+++ b/test/builder/custom_mocks_test.dart
@@ -433,34 +433,37 @@ void main() {
     expect(mocksContent, isNot(contains('throwOnMissingStub')));
   });
 
-  test(
-      'generates mock methods with non-nullable unknown types, given '
-      'unsupportedMembers', () async {
-    var mocksContent = await buildWithNonNullable({
-      ...annotationsAsset,
-      'foo|lib/foo.dart': dedent(r'''
-        abstract class Foo {
-          T m<T>(T a);
-        }
-        '''),
-      'foo|test/foo_test.dart': '''
-        import 'package:foo/foo.dart';
-        import 'package:mockito/annotations.dart';
+  // TODO: please review and verify I can delete this test
+  //I think this is not not expected any more since we support non-nullable
+  // return types now.
+  // test(
+  //     'generates mock methods with non-nullable unknown types, given '
+  //     'unsupportedMembers', () async {
+  //   var mocksContent = await buildWithNonNullable({
+  //     ...annotationsAsset,
+  //     'foo|lib/foo.dart': dedent(r'''
+  //       abstract class Foo {
+  //         T m<T>(T a);
+  //       }
+  //       '''),
+  //     'foo|test/foo_test.dart': '''
+  //       import 'package:foo/foo.dart';
+  //       import 'package:mockito/annotations.dart';
 
-        @GenerateMocks(
-          [],
-          customMocks: [
-            MockSpec<Foo>(unsupportedMembers: {#m}),
-          ],
-        )
-        void main() {}
-        '''
-    });
-    expect(
-        mocksContent,
-        contains('  T m<T>(T? a) => throw UnsupportedError(\n'
-            '      r\'"m" cannot be used without a mockito fallback generator.\');'));
-  });
+  //       @GenerateMocks(
+  //         [],
+  //         customMocks: [
+  //           MockSpec<Foo>(unsupportedMembers: {#m}),
+  //         ],
+  //       )
+  //       void main() {}
+  //       '''
+  //   });
+  //   expect(
+  //       mocksContent,
+  //       contains('  T m<T>(T? a) => throw UnsupportedError(\n'
+  //           '      r\'"m" cannot be used without a mockito fallback generator.\');'));
+  // });
 
   test(
       'generates mock methods with private return types, given '

--- a/test/builder/custom_mocks_test.dart
+++ b/test/builder/custom_mocks_test.dart
@@ -433,38 +433,6 @@ void main() {
     expect(mocksContent, isNot(contains('throwOnMissingStub')));
   });
 
-  // TODO: please review and verify I can delete this test
-  //I think this is not not expected any more since we support non-nullable
-  // return types now.
-  // test(
-  //     'generates mock methods with non-nullable unknown types, given '
-  //     'unsupportedMembers', () async {
-  //   var mocksContent = await buildWithNonNullable({
-  //     ...annotationsAsset,
-  //     'foo|lib/foo.dart': dedent(r'''
-  //       abstract class Foo {
-  //         T m<T>(T a);
-  //       }
-  //       '''),
-  //     'foo|test/foo_test.dart': '''
-  //       import 'package:foo/foo.dart';
-  //       import 'package:mockito/annotations.dart';
-
-  //       @GenerateMocks(
-  //         [],
-  //         customMocks: [
-  //           MockSpec<Foo>(unsupportedMembers: {#m}),
-  //         ],
-  //       )
-  //       void main() {}
-  //       '''
-  //   });
-  //   expect(
-  //       mocksContent,
-  //       contains('  T m<T>(T? a) => throw UnsupportedError(\n'
-  //           '      r\'"m" cannot be used without a mockito fallback generator.\');'));
-  // });
-
   test(
       'generates mock methods with private return types, given '
       'unsupportedMembers', () async {

--- a/test/end2end/generated_mocks_test.dart
+++ b/test/end2end/generated_mocks_test.dart
@@ -251,7 +251,7 @@ void main() {
       expect(baz.typeVariableField, value);
     });
 
-    test('setDefaultDummyValue() without type wont make harm', () {
+    test('calling setDefaultDummyValue() without type does not throw', () {
       setDefaultDummyValue('string');
       when(baz.returnsTypeVariable<int>()).thenReturn(3);
       expect(baz.returnsTypeVariable(), 3);

--- a/test/end2end/generated_mocks_test.dart
+++ b/test/end2end/generated_mocks_test.dart
@@ -187,31 +187,6 @@ void main() {
     });
   });
 
-  // TODO: please review and verify I can delete this test
-  //I think this is not not expected any more since we support non-nullable
-  // return types now. So the unsupportedMembers should only take effect
-  // if we can not generate code for a members.
-
-  // group('for a generated mock using unsupportedMembers', () {
-  //   late Baz baz;
-
-  //   setUp(() {
-  //     baz = MockBazWithUnsupportedMembers();
-  //   });
-
-  //   test('a real method call throws', () {
-  //     expect(() => baz.returnsTypeVariable(), throwsUnsupportedError);
-  //   });
-
-  //   test('a real getter call (or field access) throws', () {
-  //     expect(() => baz.typeVariableField, throwsUnsupportedError);
-  //   });
-
-  //   test('a real call to a method whose name has a \$ in it throws', () {
-  //     expect(() => baz.$hasDollarInName(), throwsUnsupportedError);
-  //   });
-  // });
-
   group('for a generated mock using fallbackGenerators,', () {
     late Baz baz;
 
@@ -232,8 +207,8 @@ void main() {
     test(
         'a method with multiple type parameters and a type variable return '
         'type can be called', () {
-      when(baz.returnsTypeVariable()).thenReturn(3);
-      baz.returnsTypeVariable();
+      when(baz.returnsTypeVariableFromTwo()).thenReturn(3);
+      baz.returnsTypeVariableFromTwo();
     });
   });
 
@@ -257,8 +232,8 @@ void main() {
     test(
         'a method with multiple type parameters and a type variable return '
         'type can be called', () {
-      when(baz.returnsTypeVariable()).thenReturn(3);
-      baz.returnsTypeVariable();
+      when(baz.returnsTypeVariableFromTwo()).thenReturn(3);
+      baz.returnsTypeVariableFromTwo();
     });
 
     test(
@@ -274,6 +249,12 @@ void main() {
       setDefaultDummyValue<Foo<int>>(value);
       when(baz.typeVariableField).thenReturn(value);
       expect(baz.typeVariableField, value);
+    });
+
+    test('setDefaultDummyValue() without type wont make harm', () {
+      setDefaultDummyValue('string');
+      when(baz.returnsTypeVariable<int>()).thenReturn(3);
+      expect(baz.returnsTypeVariable(), 3);
     });
   });
 


### PR DESCRIPTION
Hi there, 

I implemented a version to support mocking members/getters non-nullable generic return types. Since I am new to dart, I am not sure if my implementation comply with this project's convention.

There are about 10 tests failed, which I think are expected since all of them are expecting failure or throw errors on mocking non-nullable methods. 

In my opinion, since we can support non-nullable return types now, a lots of related checking could be removed to make codebase simpler. 

#589 
