### PR TITLE
Add `returnInOrder` to `Mock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Require Dart >= 2.19.0.
 * Require analyzer 5.11.0.
 * Fail to generate mocks of `sealed`/`base`/`final` classes.
+* Add new `thenReturnInOrder` method to mock multiple calls to a single method in order.
 
 ## 5.4.0
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ var responses = ["Purr", "Meow"];
 when(cat.sound()).thenAnswer((_) => responses.removeAt(0));
 expect(cat.sound(), "Purr");
 expect(cat.sound(), "Meow");
+
+// We can stub a method with multiple calls that happened in a particular order.
+when(cat.sound()).thenReturnInOrder(["Purr", "Meow"]);
+expect(cat.sound(), "Purr");
+expect(cat.sound(), "Meow");
+expect(() => cat.sound(), throwsA(isA<StateError>()));
 ```
 
 The [`when`], [`thenReturn`], [`thenAnswer`], and [`thenThrow`] APIs provide a

--- a/test/mockito_test.dart
+++ b/test/mockito_test.dart
@@ -168,6 +168,24 @@ void main() {
       expect(mock.getter, equals('A'));
     });
 
+    test('throws an exception if not enough answers were provided', () {
+      when(mock.methodWithNormalArgs(any)).thenReturnInOrder(['One', 'Two']);
+
+      expect(mock.methodWithNormalArgs(100), equals('One'));
+      expect(mock.methodWithNormalArgs(100), equals('Two'));
+
+      expect(
+        () => mock.methodWithNormalArgs(100),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('thenReturnInOrder does not have enough answers'),
+          ),
+        ),
+      );
+    });
+
     test('should have hashCode when it is not mocked', () {
       expect(mock.hashCode, isNotNull);
     });
@@ -236,6 +254,11 @@ void main() {
       expect(
           () => when(mock.methodReturningStream())
               .thenReturn(Stream.fromIterable(['stub'])),
+          throwsArgumentError);
+    });
+
+    test('thenReturn throws if provided expects are empty for inOrder', () {
+      expect(() => when(mock.methodReturningStream()).thenReturnInOrder([]),
           throwsArgumentError);
     });
 


### PR DESCRIPTION
Fix:
- https://github.com/dart-lang/mockito/issues/260

Allows you to add multiple return options and it will return them in order of calling, like:

```dart
when(calculator.sum(any, any)).thenReturnInOrder([2, 4]);
```

Will cause that the code will return each expected result on every call:
```dart
calculator.sum(any, any); // Returns 2
calculator.sum(any, any); // Returns 4
calculator.sum(any, any); // Exception
```