### PR TITLE
Only check formatting with the stable SDK

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -15,7 +15,23 @@ env:
 permissions: read-all
 
 jobs:
-  # Check code formatting and static analysis against stable and dev SDKs.
+  # Check code formatting with the stable SDK.
+  format:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+      - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
+        with:
+          sdk: 2.19.0
+      - id: install
+        name: Install dependencies
+        run: dart pub get
+      - name: Check formatting
+        run: dart format --output=none --set-exit-if-changed .
+        
+  # Check static analysis against stable and dev SDKs.
   analyze:
     runs-on: ubuntu-latest
     strategy:
@@ -30,8 +46,6 @@ jobs:
       - id: install
         name: Install dependencies
         run: dart pub get
-      - name: Check formatting
-        run: dart format --output=none --set-exit-if-changed .
       - name: Build generated artifacts
         run: dart pub run build_runner build
       - name: Analyze code


### PR DESCRIPTION
The code can only be formatted in one way. If there is a formatter change and stable/dev don't agree, we will always have one check failing.

