### PR TITLE
Fix code generation error on nested generic bounded type arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.4.3
+
+* Fixed the bug with code generation on nested generic bounded type arguments. [#658](https://github.com/dart-lang/mockito/issues/658) 
+
 ## 5.4.2
 
 * Require code_builder 4.5.0.

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -2051,7 +2051,20 @@ class _MockClassInfo {
 
   T _withTypeParameters<T>(Iterable<TypeParameterElement> typeParameters,
       T Function(Iterable<TypeReference>, Iterable<TypeReference>) body) {
-    final typeVars = {for (final t in typeParameters) t: _newTypeVar(t)};
+    final Map<TypeParameterElement, String> typeVars = {};
+    for (final t in typeParameters) {
+      final typeVar = _newTypeVar(t);
+      typeVars[t] = typeVar;
+      final bound = t.bound;
+      if (bound != null && bound is analyzer.InterfaceType) {
+        for (final type in bound.typeArguments) {
+          final element = type.element;
+          if (element != null && element is TypeParameterElement) {
+            typeVars[element] = typeVar;
+          }
+        }
+      }
+    }
     _typeVariableScopes.add(typeVars);
     final typeRefsWithBounds = typeParameters.map(_typeParameterReference);
     final typeRefs =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 5.4.2
+version: 5.4.3
 description: >-
   A mock framework inspired by Mockito with APIs for Fakes, Mocks,
   behavior verification, and stubbing.


### PR DESCRIPTION
Fixes #658 code generation error on nested generic bounded type arguments.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
