### PR TITLE
Make MockBuilder support build_extensions option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Require analyzer 5.12.0, allow analyzer version 6.x;
 * Add example of writing a class to mock function objects.
+* Add support for the `build_extensions` build.yaml option
 
 ## 5.4.2
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -182,7 +182,9 @@ to the filename.
 To use `build_extensions` you can use `^` on the input string to match on the project root, and `{{}}` to capture the remaining path/filename.
 
 You can also have multiple build_extensions options, but they can't conflict with each other.
-For consistency, the output pattern must always end with `.mocks.dart` and the input pattern must always end with `.dart`
+For consistency, the output pattern must always end with `.mocks.dart` and the input pattern must always end with `.dart`.
+
+If you specify a build extension, you **MUST** ensure that your patterns cover all input files that you want generate mocks from. Failing to do so will lead to the unmatched file from not being generated at all.
 
 ```yaml
 targets:

--- a/FAQ.md
+++ b/FAQ.md
@@ -167,3 +167,37 @@ it's done.  It's very straightforward.
 
 [`verify`]: https://pub.dev/documentation/mockito/latest/mockito/verify.html
 [`verifyInOrder`]: https://pub.dev/documentation/mockito/latest/mockito/verifyInOrder.html
+
+
+### How can I customize where Mockito outputs its mocks?
+
+Mockito supports configuration of outputs by the configuration provided by the `build`
+package by creating (if it doesn't exist already) the `build.yaml` at the root folder
+of the project.
+
+It uses the `build_extensions` option, which can be used to alter not only the output directory but you
+can also do other filename manipulation, eg.: append/prepend strings to the filename or add another extension
+to the filename.
+
+To use `build_extensions` you can use `^` on the input string to match on the project root, and `{{}}` to capture the remaining path/filename.
+
+You can also have multiple build_extensions options, but they can't conflict with each other.
+For consistency, the output pattern must always end with `.mocks.dart` and the input pattern must always end with `.dart`
+
+```yaml
+targets:
+  $default:
+    builders:
+      mockito|mockBuilder:
+        generate_for:
+        options:
+          # build_extensions takes a source pattern and if it matches it will transform the output
+          # to your desired path. The default behaviour is to the .mocks.dart file to be in the same
+          # directory as the source .dart file. As seen below this is customizable, but the generated
+          # file must always end in `.mocks.dart`. 
+          build_extensions:
+            '^tests/{{}}.dart' : 'tests/mocks/{{}}.mocks.dart' 
+            '^integration-tests/{{}}.dart' : 'integration-tests/{{}}.mocks.dart' 
+```
+
+Also, you can also check out the example configuration in the Mockito repository. 

--- a/build.yaml
+++ b/build.yaml
@@ -10,8 +10,13 @@ targets:
           # to your desired path. The default behaviour is to the .mocks.dart file to be in the same
           # directory as the source .dart file. As seen below this is customizable, but the generated
           # file must always end in `.mocks.dart`.
+          #
+          # If you specify custom build_extensions you MUST ensure that they cover all input files
           build_extensions:
             '^example/build_extensions/{{}}.dart' : 'example/build_extensions/mocks/{{}}.mocks.dart'
+            '^example/example.dart' : 'example/example.mocks.dart'
+            '^example/iss/{{}}.dart' : 'example/iss/{{}}.mocks.dart'
+            '^test/end2end/{{}}.dart' : 'test/end2end/{{}}.mocks.dart'
 
 builders:
   mockBuilder:

--- a/build.yaml
+++ b/build.yaml
@@ -5,6 +5,13 @@ targets:
         generate_for:
           - example/**.dart
           - test/end2end/*.dart
+        options:
+          # build_extensions takes a source pattern and if it matches it will transform the output
+          # to your desired path. The default behaviour is to the .mocks.dart file to be in the same
+          # directory as the source .dart file. As seen below this is customizable, but the generated
+          # file must always end in `.mocks.dart`.
+          build_extensions:
+            '^example/build_extensions/{{}}.dart' : 'example/build_extensions/mocks/{{}}.mocks.dart'
 
 builders:
   mockBuilder:

--- a/example/build_extensions/example.dart
+++ b/example/build_extensions/example.dart
@@ -1,0 +1,40 @@
+// Copyright 2023 Dart Mockito authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test_api/scaffolding.dart';
+
+// Because we customized the `build_extensions` option, we can output
+// the generated mocks in a diferent directory
+import 'mocks/example.mocks.dart';
+
+class Dog {
+  String sound() => "bark";
+  bool? eatFood(String? food) => true;
+  Future<void> chew() async => print('Chewing...');
+  int? walk(List<String>? places) => 1;
+}
+
+@GenerateNiceMocks([MockSpec<Dog>()])
+void main() {
+  test("Verify some dog behaviour", () async {
+    MockDog mockDog = MockDog();
+    when(mockDog.eatFood(any));
+
+    mockDog.eatFood("biscuits");
+
+    verify(mockDog.eatFood(any)).called(1);
+  });
+}

--- a/example/build_extensions/example.dart
+++ b/example/build_extensions/example.dart
@@ -21,7 +21,7 @@ import 'package:test_api/scaffolding.dart';
 import 'mocks/example.mocks.dart';
 
 class Dog {
-  String sound() => "bark";
+  String sound() => 'bark';
   bool? eatFood(String? food) => true;
   Future<void> chew() async => print('Chewing...');
   int? walk(List<String>? places) => 1;
@@ -29,11 +29,11 @@ class Dog {
 
 @GenerateNiceMocks([MockSpec<Dog>()])
 void main() {
-  test("Verify some dog behaviour", () async {
+  test('Verify some dog behaviour', () async {
     MockDog mockDog = MockDog();
     when(mockDog.eatFood(any));
 
-    mockDog.eatFood("biscuits");
+    mockDog.eatFood('biscuits');
 
     verify(mockDog.eatFood(any)).called(1);
   });

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -63,18 +63,40 @@ import 'package:source_gen/source_gen.dart';
 /// 'foo.mocks.dart' will be created.
 class MockBuilder implements Builder {
   @override
+  final Map<String, List<String>> buildExtensions = {
+    '.dart': ['.mocks.dart']
+  };
+
+  MockBuilder({Map<String, List<String>>? buildExtensions}) {
+    this.buildExtensions.addAll(buildExtensions ?? {});
+  }
+
+  @override
   Future<void> build(BuildStep buildStep) async {
     if (!await buildStep.resolver.isLibrary(buildStep.inputId)) return;
     final entryLib = await buildStep.inputLibrary;
     final sourceLibIsNonNullable = entryLib.isNonNullableByDefault;
-    final mockLibraryAsset = buildStep.inputId.changeExtension('.mocks.dart');
+
+    // While it can be acceptable that we get more than 2 allowedOutputs,
+    // because it's the general one and the user defined one. Having
+    // more, means that user has conflicting patterns so we should throw.
+    if (buildStep.allowedOutputs.length > 2) {
+      throw ArgumentError('Build_extensions has conflicting outputs on file '
+          '`${buildStep.inputId.path}`, it usually caused by missconfiguration '
+          'on your `build.yaml` file');
+    }
+    // if not single, we always choose the user defined one.
+    final mockLibraryAsset = buildStep.allowedOutputs.singleOrNull ??
+        buildStep.allowedOutputs
+            .where((element) =>
+                element != buildStep.inputId.changeExtension('.mocks.dart'))
+            .single;
     final inheritanceManager = InheritanceManager3();
     final mockTargetGatherer =
         _MockTargetGatherer(entryLib, inheritanceManager);
 
-    final entryAssetId = await buildStep.resolver.assetIdForElement(entryLib);
     final assetUris = await _resolveAssetUris(buildStep.resolver,
-        mockTargetGatherer._mockTargets, entryAssetId.path, entryLib);
+        mockTargetGatherer._mockTargets, mockLibraryAsset.path, entryLib);
 
     final mockLibraryInfo = _MockLibraryInfo(mockTargetGatherer._mockTargets,
         assetUris: assetUris,
@@ -240,11 +262,6 @@ $rawOutput
     }
     return element.library!;
   }
-
-  @override
-  final buildExtensions = const {
-    '.dart': ['.mocks.dart']
-  };
 }
 
 /// An [Element] visitor which collects the elements of all of the
@@ -2304,7 +2321,29 @@ class _AvoidConflictsAllocator implements Allocator {
 }
 
 /// A [MockBuilder] instance for use by `build.yaml`.
-Builder buildMocks(BuilderOptions options) => MockBuilder();
+Builder buildMocks(BuilderOptions options) {
+  final buildExtensions = options.config['build_extensions'];
+  if (buildExtensions == null) return MockBuilder();
+  if (buildExtensions is! Map) {
+    throw ArgumentError(
+        'build_extensions should be a map from inputs to outputs');
+  }
+  final result = <String, List<String>>{};
+  for (final entry in buildExtensions.entries) {
+    final input = entry.key;
+    final output = entry.value;
+    if (input is! String || !input.endsWith('.dart')) {
+      throw ArgumentError('Invalid key in build_extensions `$input`, it '
+          'should be a string ending with `.dart`');
+    }
+    if (output is! String || !output.endsWith('.mocks.dart')) {
+      throw ArgumentError('Invalid key in build_extensions `$output`, it '
+          'should be a string ending with `mocks.dart`');
+    }
+    result[input] = [output];
+  }
+  return MockBuilder(buildExtensions: result);
+}
 
 extension on Element {
   /// Returns the "full name" of a class or method element.

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -76,12 +76,12 @@ class MockBuilder implements Builder {
     final entryLib = await buildStep.inputLibrary;
     final sourceLibIsNonNullable = entryLib.isNonNullableByDefault;
 
-    if (buildStep.allowedOutputs.length > 1) {
-      throw ArgumentError('Build_extensions has conflicting outputs on file '
-          '`${buildStep.inputId.path}`, it usually caused by missconfiguration '
-          'on your `build.yaml` file');
+    final mockLibraryAsset = buildStep.allowedOutputs.singleOrNull;
+    if (mockLibraryAsset == null) {
+      throw ArgumentError('Build_extensions has missing or conflicting outputs for '
+          '`${buildStep.inputId.path}`, this is usually caused by a misconfigured '
+          'build extension override in `build.yaml`');
     }
-    final mockLibraryAsset = buildStep.allowedOutputs.single;
 
     final inheritanceManager = InheritanceManager3();
     final mockTargetGatherer =

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -63,13 +63,12 @@ import 'package:source_gen/source_gen.dart';
 /// 'foo.mocks.dart' will be created.
 class MockBuilder implements Builder {
   @override
-  final Map<String, List<String>> buildExtensions = {
-    '.dart': ['.mocks.dart']
-  };
+  final Map<String, List<String>> buildExtensions;
 
-  MockBuilder({Map<String, List<String>>? buildExtensions}) {
-    this.buildExtensions.addAll(buildExtensions ?? {});
-  }
+  const MockBuilder(
+      {this.buildExtensions = const {
+        '.dart': ['.mocks.dart']
+      }});
 
   @override
   Future<void> build(BuildStep buildStep) async {
@@ -77,20 +76,13 @@ class MockBuilder implements Builder {
     final entryLib = await buildStep.inputLibrary;
     final sourceLibIsNonNullable = entryLib.isNonNullableByDefault;
 
-    // While it can be acceptable that we get more than 2 allowedOutputs,
-    // because it's the general one and the user defined one. Having
-    // more, means that user has conflicting patterns so we should throw.
-    if (buildStep.allowedOutputs.length > 2) {
+    if (buildStep.allowedOutputs.length > 1) {
       throw ArgumentError('Build_extensions has conflicting outputs on file '
           '`${buildStep.inputId.path}`, it usually caused by missconfiguration '
           'on your `build.yaml` file');
     }
-    // if not single, we always choose the user defined one.
-    final mockLibraryAsset = buildStep.allowedOutputs.singleOrNull ??
-        buildStep.allowedOutputs
-            .where((element) =>
-                element != buildStep.inputId.changeExtension('.mocks.dart'))
-            .single;
+    final mockLibraryAsset = buildStep.allowedOutputs.single;
+
     final inheritanceManager = InheritanceManager3();
     final mockTargetGatherer =
         _MockTargetGatherer(entryLib, inheritanceManager);

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -2337,7 +2337,7 @@ Builder buildMocks(BuilderOptions options) {
           'should be a string ending with `.dart`');
     }
     if (output is! String || !output.endsWith('.mocks.dart')) {
-      throw ArgumentError('Invalid key in build_extensions `$output`, it '
+      throw ArgumentError('Invalid value in build_extensions `$output`, it '
           'should be a string ending with `mocks.dart`');
     }
     result[input] = [output];

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -78,7 +78,8 @@ class MockBuilder implements Builder {
 
     final mockLibraryAsset = buildStep.allowedOutputs.singleOrNull;
     if (mockLibraryAsset == null) {
-      throw ArgumentError('Build_extensions has missing or conflicting outputs for '
+      throw ArgumentError(
+          'Build_extensions has missing or conflicting outputs for '
           '`${buildStep.inputId.path}`, this is usually caused by a misconfigured '
           'build extension override in `build.yaml`');
     }

--- a/test/builder/auto_mocks_test.dart
+++ b/test/builder/auto_mocks_test.dart
@@ -3679,7 +3679,7 @@ void main() {
         }
         ''',
       }, config: {
-        "build_extensions": {"^test/{{}}.dart": "test/mocks/{{}}.mocks.dart"}
+        'build_extensions': {'^test/{{}}.dart': 'test/mocks/{{}}.mocks.dart'}
       });
       final mocksAsset = AssetId('foo', 'test/mocks/foo_test.mocks.dart');
       final mocksContent = utf8.decode(writer.assets[mocksAsset]!);
@@ -3703,9 +3703,9 @@ void main() {
         }
         ''',
           }, config: {
-            "build_extensions": {
-              "^test/{{}}.dart": "test/mocks/{{}}.mocks.dart",
-              "test/{{}}.dart": "test/{{}}.something.mocks.dart"
+            'build_extensions': {
+              '^test/{{}}.dart': 'test/mocks/{{}}.mocks.dart',
+              'test/{{}}.dart': 'test/{{}}.something.mocks.dart'
             }
           }),
           throwsArgumentError);
@@ -3735,7 +3735,7 @@ void main() {
         }
         ''',
           }, config: {
-            "build_extensions": {"^test/{{}}": "test/mocks/{{}}.mocks.dart"}
+            'build_extensions': {'^test/{{}}': 'test/mocks/{{}}.mocks.dart'}
           }),
           throwsArgumentError);
       final mocksAsset = AssetId('foo', 'test/mocks/foo_test.mocks.dart');
@@ -3761,7 +3761,7 @@ void main() {
         }
         ''',
           }, config: {
-            "build_extensions": {"^test/{{}}.dart": "test/mocks/{{}}.g.dart"}
+            'build_extensions': {'^test/{{}}.dart': 'test/mocks/{{}}.g.dart'}
           }),
           throwsArgumentError);
       final mocksAsset = AssetId('foo', 'test/mocks/foo_test.mocks.dart');


### PR DESCRIPTION
This PR changes the behaviour of the `buildMocks` factory, in order to support the `build_extensions` option. 

This is useful in order to change the destination directory of the mocks, allowing for more customizability as in [this article](https://simonbinder.eu/posts/build_directory_moves/). 

This change is a bit opinionated, because it forces the end-user to have a output filename pattern that ends with `.mocks.dart` in order to be consistent with the already generated files from mockito. It also forces the user, to have an input pattern ending with `.dart`.

Closes https://github.com/dart-lang/mockito/issues/545


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
