### PR TITLE
Run formatter with SDK 3.2.0

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - uses: dart-lang/setup-dart@8a4b97ea2017cc079571daec46542f76189836b1
         with:
-          sdk: 3.0.0
+          sdk: 3.2.0
       - id: install
         name: Install dependencies
         run: dart pub get


### PR DESCRIPTION
To make the check happy. There was a change to formatter and since we format with a HEAD version of dart format internally, now the format check is unhappy @ github.

