### PR TITLE
Use `posix` path style for relative imports

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -220,8 +220,8 @@ $rawOutput
         if (typeAssetId.path.startsWith('lib/')) {
           typeUris[element] = typeAssetId.uri.toString();
         } else {
-          typeUris[element] = p.Context(style: p.Style.posix)
-              .relative(typeAssetId.path, from: p.dirname(entryAssetPath));
+          typeUris[element] = p.posix.relative(typeAssetId.path,
+              from: p.posix.dirname(entryAssetPath));
         }
       } on UnresolvableAssetException {
         // Asset may be in a summary.

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -220,8 +220,8 @@ $rawOutput
         if (typeAssetId.path.startsWith('lib/')) {
           typeUris[element] = typeAssetId.uri.toString();
         } else {
-          typeUris[element] =
-              p.relative(typeAssetId.path, from: p.dirname(entryAssetPath));
+          typeUris[element] = p.Context(style: p.Style.posix)
+              .relative(typeAssetId.path, from: p.dirname(entryAssetPath));
         }
       } on UnresolvableAssetException {
         // Asset may be in a summary.


### PR DESCRIPTION
## Details

Fixes #711 

Generated _relative imports_ paths on windows used backslashes instead of forwards slashes.
This broke the `DartFormatter` and the build_runner aborted.

### Fix

I specifically added `p.Context(style: p.Style.posix)` to the `.relative` part of the path generation.
This ensures the import paths contain only forward slashes.
             
---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
