### PR TITLE
Enable MockSpec superclasses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ coverage/
 
 # ignore generated mocks
 **/*.mocks.dart
+
+# ide folders
+.idea

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -574,6 +574,11 @@ class _MockTargetGatherer {
       int index,
       List<ast.CollectionElement> mockSpecAsts,
       {bool nice = false}) {
+    // need to get the parent until type name is not MockSpec to allow inheritance
+    while(mockSpec.type?.element?.name != "MockSpec") {
+      mockSpec = mockSpec.getField("(super)")!;
+    }
+
     final mockSpecType = mockSpec.type as analyzer.InterfaceType;
     assert(mockSpecType.typeArguments.length == 1);
     final mockType = _mockType(mockSpecAsts[index]);
@@ -681,10 +686,10 @@ class _MockTargetGatherer {
       throw InvalidMockitoAnnotationException(
           'The GenerateNiceMocks "mockSpecs" argument is missing');
     }
-    final mockSpecAsts = _niceMocksAst(annotation.annotationAst).elements;
+    final mockSpecAsts = _niceMocksAst(annotation.annotationAst).elements.toList();
     return mockSpecsField.toListValue()!.mapIndexed((index, mockSpec) =>
         _mockTargetFromMockSpec(
-            mockSpec, entryLib, index, mockSpecAsts.toList(),
+            mockSpec, entryLib, index, mockSpecAsts,
             nice: true));
   }
 


### PR DESCRIPTION
In this PR I add a check on mockSpec type to be sure that is an effective MockSpec and not an extension of it. In this way we could use a MockSpec superclass to use default constructor parameters or added values.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
