### PR TITLE
Switch to`package:dart_flutter_team_lints`

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,8 @@
-include: package:lints/recommended.yaml
+include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
+  errors:
+    lines_longer_than_80_chars: ignore
   language:
     strict-casts: true
 

--- a/example/build_extensions/example.dart
+++ b/example/build_extensions/example.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ignore_for_file: unreachable_from_main
+
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test_api/scaffolding.dart';
@@ -30,7 +32,7 @@ class Dog {
 @GenerateNiceMocks([MockSpec<Dog>()])
 void main() {
   test('Verify some dog behaviour', () async {
-    MockDog mockDog = MockDog();
+    var mockDog = MockDog();
     when(mockDog.eatFood(any));
 
     mockDog.eatFood('biscuits');

--- a/example/example.dart
+++ b/example/example.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: unreachable_from_main
+
 import 'dart:async';
 
 import 'package:mockito/annotations.dart';
@@ -229,7 +231,7 @@ void main() {
     final cat = FakeCat();
 
     cat.eatFood('Milk'); // Prints 'Fake eat Milk'.
-    expect(() => cat.sleep(), throwsUnimplementedError);
+    expect(cat.sleep, throwsUnimplementedError);
   });
 
   test('Relaxed mock class', () {

--- a/example/iss/iss.dart
+++ b/example/iss/iss.dart
@@ -41,9 +41,10 @@ class IssLocator {
     // at this moment.
     final uri = Uri.parse('http://api.open-notify.org/iss-now.json');
     final rs = await client.get(uri);
-    final data = jsonDecode(rs.body);
-    final latitude = double.parse(data['iss_position']['latitude'] as String);
-    final longitude = double.parse(data['iss_position']['longitude'] as String);
+    final data = jsonDecode(rs.body) as Map;
+    final position = data['iss_position'] as Map;
+    final latitude = double.parse(position['latitude'] as String);
+    final longitude = double.parse(position['longitude'] as String);
     _position = Point<double>(latitude, longitude);
   }
 }

--- a/example/iss/iss_test.dart
+++ b/example/iss/iss_test.dart
@@ -27,8 +27,8 @@ void main() {
   // verify the calculated distance between them.
   group('Spherical distance', () {
     test('London - Paris', () {
-      final london = Point(51.5073, -0.1277);
-      final paris = Point(48.8566, 2.3522);
+      final london = const Point(51.5073, -0.1277);
+      final paris = const Point(48.8566, 2.3522);
       final d = sphericalDistanceKm(london, paris);
       // London should be approximately 343.5km
       // (+/- 0.1km) from Paris.
@@ -36,8 +36,8 @@ void main() {
     });
 
     test('San Francisco - Mountain View', () {
-      final sf = Point(37.783333, -122.416667);
-      final mtv = Point(37.389444, -122.081944);
+      final sf = const Point(37.783333, -122.416667);
+      final mtv = const Point(37.389444, -122.081944);
       final d = sphericalDistanceKm(sf, mtv);
       // San Francisco should be approximately 52.8km
       // (+/- 0.1km) from Mountain View.
@@ -52,8 +52,8 @@ void main() {
   // second predefined location. This test runs asynchronously.
   group('ISS spotter', () {
     test('ISS visible', () async {
-      final sf = Point(37.783333, -122.416667);
-      final mtv = Point(37.389444, -122.081944);
+      final sf = const Point(37.783333, -122.416667);
+      final mtv = const Point(37.389444, -122.081944);
       final IssLocator locator = MockIssLocator();
       // Mountain View should be visible from San Francisco.
       when(locator.currentPosition).thenReturn(sf);
@@ -63,8 +63,8 @@ void main() {
     });
 
     test('ISS not visible', () async {
-      final london = Point(51.5073, -0.1277);
-      final mtv = Point(37.389444, -122.081944);
+      final london = const Point(51.5073, -0.1277);
+      final mtv = const Point(37.389444, -122.081944);
       final IssLocator locator = MockIssLocator();
       // London should not be visible from Mountain View.
       when(locator.currentPosition).thenReturn(london);

--- a/lib/src/dummies.dart
+++ b/lib/src/dummies.dart
@@ -134,7 +134,7 @@ List<Object?> _defaultDummies = [
   <Never>[],
   <Never>{},
   <Never, Never>{},
-  Stream<Never>.empty(),
+  const Stream<Never>.empty(),
   SplayTreeSet<Never>(),
   SplayTreeMap<Never, Never>(),
 ];
@@ -155,6 +155,7 @@ T? dummyValueOrNull<T>(Object parent, Invocation invocation) {
 T dummyValue<T>(Object parent, Invocation invocation) {
   final value = dummyValueOrNull<T>(parent, invocation);
   if (value is T) return value;
+  // ignore: only_throw_errors
   throw MissingDummyValueError(T);
 }
 

--- a/lib/src/invocation_matcher.dart
+++ b/lib/src/invocation_matcher.dart
@@ -14,7 +14,7 @@
 
 import 'package:collection/collection.dart';
 import 'package:matcher/matcher.dart';
-import 'package:mockito/src/mock.dart';
+import 'mock.dart';
 
 /// Returns a matcher that expects an invocation that matches arguments given.
 ///
@@ -130,7 +130,7 @@ class _InvocationMatcher implements Matcher {
   // Specifically, if a Matcher is passed as an argument, we'd like to get an
   // error like "Expected fly(miles: > 10), Actual: fly(miles: 5)".
   @override
-  Description describeMismatch(item, Description d, _, __) {
+  Description describeMismatch(dynamic item, Description d, _, __) {
     if (item is Invocation) {
       d = d.add('Does not match ');
       return _describeInvocation(d, item);
@@ -139,7 +139,7 @@ class _InvocationMatcher implements Matcher {
   }
 
   @override
-  bool matches(item, _) =>
+  bool matches(dynamic item, _) =>
       item is Invocation &&
       _invocation.memberName == item.memberName &&
       _invocation.isSetter == item.isSetter &&
@@ -156,7 +156,7 @@ class _MatcherEquality extends DeepCollectionEquality /* <Matcher | E> */ {
   const _MatcherEquality();
 
   @override
-  bool equals(e1, e2) {
+  bool equals(Object? e1, Object? e2) {
     // All argument matches are wrapped in `ArgMatcher`, so we have to unwrap
     // them into the raw `Matcher` type in order to finish our equality checks.
     if (e1 is ArgMatcher) {

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -968,7 +968,6 @@ class VerificationResult {
   @Deprecated(
       'captured should be considered final - assigning this field may be '
       'removed as early as Mockito 5.0.0')
-  // ignore: unnecessary_getters_setters
   set captured(List<dynamic> captured) => _captured = captured;
 
   /// The number of calls matched in this verification.

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -22,11 +22,12 @@ import 'dart:collection';
 
 import 'package:matcher/expect.dart';
 import 'package:meta/meta.dart';
-import 'package:mockito/src/call_pair.dart';
-import 'package:mockito/src/dummies.dart' show resetDummyBuilders;
-import 'package:mockito/src/invocation_matcher.dart';
 // ignore: deprecated_member_use
 import 'package:test_api/fake.dart';
+
+import 'call_pair.dart';
+import 'dummies.dart' show resetDummyBuilders;
+import 'invocation_matcher.dart';
 
 /// Whether a [when] call is "in progress."
 ///
@@ -195,7 +196,7 @@ mixin class Mock {
   int get hashCode => _givenHashCode ?? 0;
 
   @override
-  bool operator ==(other) => (_givenHashCode != null && other is Mock)
+  bool operator ==(Object other) => (_givenHashCode != null && other is Mock)
       ? _givenHashCode == other._givenHashCode
       : identical(this, other);
 
@@ -392,8 +393,7 @@ class _InvocationForMatchedArguments extends Invocation {
   // by a stored value in [_storedNamedArgs].
   static Map<Symbol, dynamic> _reconstituteNamedArgs(Invocation invocation) {
     final namedArguments = <Symbol, dynamic>{};
-    final storedNamedArgSymbols =
-        _storedNamedArgs.keys.map((name) => Symbol(name));
+    final storedNamedArgSymbols = _storedNamedArgs.keys.map(Symbol.new);
 
     // Iterate through [invocation]'s named args, validate them, and add them
     // to the return map.
@@ -509,13 +509,13 @@ T named<T extends Mock>(T mock, {String? name, int? hashCode}) => mock
   .._givenHashCode = hashCode;
 
 /// Clear stubs of, and collected interactions with [mock].
-void reset(var mock) {
+void reset(Mock mock) {
   mock._realCalls.clear();
   mock._responses.clear();
 }
 
 /// Clear the collected interactions with [mock].
-void clearInteractions(var mock) {
+void clearInteractions(Mock mock) {
   mock._realCalls.clear();
 }
 
@@ -557,6 +557,7 @@ class PostExpectation<T> {
   /// Store an exception to throw when this method stub is called.
   void thenThrow(Object throwable) {
     return _completeWhen((Invocation _) {
+      // ignore: only_throw_errors
       throw throwable;
     });
   }
@@ -668,7 +669,7 @@ class InvocationMatcher {
     return true;
   }
 
-  bool isMatchingArg(roleArg, actArg) {
+  bool isMatchingArg(dynamic roleArg, dynamic actArg) {
     if (roleArg is ArgMatcher) {
       return roleArg.matcher.matches(actArg, {});
     } else {
@@ -1133,6 +1134,7 @@ List<VerificationResult> Function<T>(List<T> recordedInvocations)
         matchedCalls.add(matched.realCall);
         verificationResults.add(VerificationResult._(1, matched.capturedArgs));
         time = matched.realCall.timeStamp;
+        // ignore: avoid_catching_errors
       } on StateError {
         final mocks = tmpVerifyCalls.map((vc) => vc.mock).toSet();
         final allInvocations =
@@ -1154,14 +1156,14 @@ List<VerificationResult> Function<T>(List<T> recordedInvocations)
   };
 }
 
-void _throwMockArgumentError(String method, var nonMockInstance) {
+void _throwMockArgumentError(String method, dynamic nonMockInstance) {
   if (nonMockInstance == null) {
     throw ArgumentError('$method was called with a null argument');
   }
   throw ArgumentError('$method must only be given a Mock object');
 }
 
-void verifyNoMoreInteractions(var mock) {
+void verifyNoMoreInteractions(dynamic mock) {
   if (mock is Mock) {
     final unverified = mock._realCalls.where((inv) => !inv.verified).toList();
     if (unverified.isNotEmpty) {
@@ -1172,7 +1174,7 @@ void verifyNoMoreInteractions(var mock) {
   }
 }
 
-void verifyZeroInteractions(var mock) {
+void verifyZeroInteractions(dynamic mock) {
   if (mock is Mock) {
     if (mock._realCalls.isNotEmpty) {
       fail('No interaction expected, but following found: '

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dev_dependencies:
   build_runner: ^2.0.0
   build_test: ^2.0.0
   build_web_compilers: '>=3.0.0 <5.0.0'
+  dart_flutter_team_lints: ^2.1.1
   http: ^1.0.0
-  lints: ^3.0.0
   package_config: ^2.0.0
   test: ^1.16.0

--- a/test/builder/auto_mocks_test.dart
+++ b/test/builder/auto_mocks_test.dart
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 @TestOn('vm')
+library;
+
 import 'dart:convert' show utf8;
 
 import 'package:build/build.dart';
@@ -101,7 +103,7 @@ void main() {
           languageVersion: LanguageVersion(3, 3))
     ]);
 
-    await testBuilder(buildMocks(BuilderOptions({})), sourceAssets,
+    await testBuilder(buildMocks(const BuilderOptions({})), sourceAssets,
         writer: writer, packageConfig: packageConfig);
     final mocksAsset = AssetId('foo', 'test/foo_test.mocks.dart');
     return utf8.decode(writer.assets[mocksAsset]!);
@@ -3753,7 +3755,7 @@ void main() {
   });
 }
 
-TypeMatcher<List<int>> _containsAllOf(a, [b]) => decodedMatches(
+TypeMatcher<List<int>> _containsAllOf(Object? a, [Object? b]) => decodedMatches(
     b == null ? allOf(contains(a)) : allOf(contains(a), contains(b)));
 
 /// Expect that [testBuilder], given [assets], in a package which has opted into
@@ -3774,13 +3776,13 @@ void _expectBuilderThrows({
   expect(
       () => withEnabledExperiments(
             () => testBuilder(
-              buildMocks(BuilderOptions({})),
+              buildMocks(const BuilderOptions({})),
               assets,
               packageConfig: packageConfig,
             ),
             enabledExperiments,
           ),
-      throwsA(TypeMatcher<InvalidMockitoAnnotationException>()
+      throwsA(const TypeMatcher<InvalidMockitoAnnotationException>()
           .having((e) => e.message, 'message', message)));
 }
 

--- a/test/builder/custom_mocks_test.dart
+++ b/test/builder/custom_mocks_test.dart
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 @TestOn('vm')
+library;
+
 import 'dart:convert' show utf8;
 
 import 'package:build/build.dart';
@@ -21,7 +23,7 @@ import 'package:mockito/src/builder.dart';
 import 'package:package_config/package_config.dart';
 import 'package:test/test.dart';
 
-Builder buildMocks(BuilderOptions options) => MockBuilder();
+Builder buildMocks(BuilderOptions options) => const MockBuilder();
 
 const annotationsAsset = {
   'mockito|lib/annotations.dart': '''
@@ -81,11 +83,6 @@ void main() {}
 '''
 };
 
-const _constructorWithThrowOnMissingStub = '''
-MockFoo() {
-    _i1.throwOnMissingStub(this);
-  }''';
-
 void main() {
   late InMemoryAssetWriter writer;
 
@@ -97,7 +94,7 @@ void main() {
           packageUriRoot: Uri.file('/foo/lib/'),
           languageVersion: LanguageVersion(3, 3))
     ]);
-    await testBuilder(buildMocks(BuilderOptions({})), sourceAssets,
+    await testBuilder(buildMocks(const BuilderOptions({})), sourceAssets,
         writer: writer, packageConfig: packageConfig);
     final mocksAsset = AssetId('foo', 'test/foo_test.mocks.dart');
     return utf8.decode(writer.assets[mocksAsset]!);
@@ -1755,9 +1752,6 @@ void main() {
   });
 }
 
-TypeMatcher<List<int>> _containsAllOf(a, [b]) => decodedMatches(
-    b == null ? allOf(contains(a)) : allOf(contains(a), contains(b)));
-
 /// Expect that [testBuilder], given [assets], throws an
 /// [InvalidMockitoAnnotationException] with a message containing [message].
 void _expectBuilderThrows({
@@ -1765,8 +1759,9 @@ void _expectBuilderThrows({
   required dynamic /*String|Matcher<List<int>>*/ message,
 }) {
   expect(
-      () async => await testBuilder(buildMocks(BuilderOptions({})), assets),
-      throwsA(TypeMatcher<InvalidMockitoAnnotationException>()
+      () async =>
+          await testBuilder(buildMocks(const BuilderOptions({})), assets),
+      throwsA(const TypeMatcher<InvalidMockitoAnnotationException>()
           .having((e) => e.message, 'message', message)));
 }
 

--- a/test/capture_test.dart
+++ b/test/capture_test.dart
@@ -34,11 +34,7 @@ void main() {
     mock = _MockedClass();
   });
 
-  tearDown(() {
-    // In some of the tests that expect an Error to be thrown, Mockito's
-    // global state can become invalid. Reset it.
-    resetMockitoState();
-  });
+  tearDown(resetMockitoState);
 
   group('capture', () {
     test('captureAny should match anything', () {

--- a/test/end2end/generated_mocks_test.dart
+++ b/test/end2end/generated_mocks_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: inference_failure_on_function_invocation, inference_failure_on_instance_creation
+
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
@@ -42,11 +44,7 @@ void main() {
       fooSub = MockFooSub();
     });
 
-    tearDown(() {
-      // In some of the tests that expect an Error to be thrown, Mockito's
-      // global state can become invalid. Reset it.
-      resetMockitoState();
-    });
+    tearDown(resetMockitoState);
 
     test('a method with a positional parameter can be stubbed', () {
       when(foo.positionalParameter(42)).thenReturn('Stubbed');
@@ -150,15 +148,17 @@ void main() {
       when(foo.namedParameter(x: 42)).thenReturn('Stubbed');
       expect(
         () => foo.namedParameter(x: 43),
-        throwsA(TypeMatcher<MissingStubError>().having((e) => e.toString(),
-            'toString()', contains('namedParameter({x: 43})'))),
+        throwsA(const TypeMatcher<MissingStubError>().having(
+            (e) => e.toString(),
+            'toString()',
+            contains('namedParameter({x: 43})'))),
       );
     });
 
     test('an unstubbed getter throws', () {
       expect(
         () => foo.getter,
-        throwsA(TypeMatcher<MissingStubError>()
+        throwsA(const TypeMatcher<MissingStubError>()
             .having((e) => e.toString(), 'toString()', contains('getter'))),
       );
     });
@@ -192,7 +192,7 @@ void main() {
       baz = MockBazWithUnsupportedMembers<Bar>();
     });
 
-    tearDown(() => resetMockitoState());
+    tearDown(resetMockitoState);
 
     test('a real method call that returns private type throws', () {
       expect(() => baz.returnsPrivate(), throwsUnsupportedError);
@@ -311,15 +311,13 @@ void main() {
       when(foo.returnsBar(42)).thenReturn(Bar());
       final bar = foo.returnsBar(43);
       expect(
-          () => bar.f(),
+          bar.f,
           throwsA(isA<FakeUsedError>().having(
               (e) => e.toString(), 'toString()', contains('returnsBar(43)'))));
     });
     group('a method returning Future<T>', () {
       final bar = Bar();
-      tearDown(() {
-        resetMockitoState();
-      });
+      tearDown(resetMockitoState);
       test('returns a fake future if unstubbed', () {
         expect(foo.returnsFuture(bar), isA<SmartFake>());
       });

--- a/test/invocation_matcher_test.dart
+++ b/test/invocation_matcher_test.dart
@@ -140,7 +140,7 @@ void main() {
 
 abstract class Interface {
   bool? get value;
-  set value(value);
+  set value(bool? value);
   void say(String text);
   void eat(String food, {bool? alsoDrink});
   void lie([bool? facingDown]);
@@ -162,7 +162,7 @@ class Stub implements Interface {
 }
 
 // Inspired by shouldFail() from package:test, which doesn't expose it to users.
-void shouldFail(value, Matcher matcher, expected) {
+void shouldFail(Invocation value, Matcher matcher, Object? expected) {
   const reason = 'Expected to fail.';
   try {
     expect(value, matcher);
@@ -177,6 +177,6 @@ void shouldFail(value, Matcher matcher, expected) {
   }
 }
 
-void shouldPass(value, Matcher matcher) {
+void shouldPass(Invocation value, Matcher matcher) {
   expect(value, matcher);
 }

--- a/test/manual_mocks_test.dart
+++ b/test/manual_mocks_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ignore_for_file: unreachable_from_main, inference_failure_on_function_invocation
+
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -84,11 +86,7 @@ void main() {
     mock = MockedClass();
   });
 
-  tearDown(() {
-    // In some of the tests that expect an Error to be thrown, Mockito's
-    // global state can become invalid. Reset it.
-    resetMockitoState();
-  });
+  tearDown(resetMockitoState);
 
   group('when()', () {
     test(
@@ -99,14 +97,14 @@ void main() {
       expect(
           () => when(mock.notMockedNonNullableParam((any as dynamic) as int))
               .thenReturn('Mock'),
-          throwsA(TypeMatcher<TypeError>()));
+          throwsA(const TypeMatcher<TypeError>()));
     });
 
     test(
         'cannot operate on method with non-nullable return type without a '
         'manual mock', () {
       expect(() => when(mock.notMockedNonNullableReturn()).thenReturn(7),
-          throwsA(TypeMatcher<TypeError>()));
+          throwsA(const TypeMatcher<TypeError>()));
     });
 
     test('should mock method with non-nullable params', () {
@@ -169,8 +167,8 @@ void main() {
     test(
         'should throw a TypeError on a call to a function with a non-nullable '
         'return type without a matching stub', () {
-      expect(
-          () => mock.nonNullableReturn(43), throwsA(TypeMatcher<TypeError>()));
+      expect(() => mock.nonNullableReturn(43),
+          throwsA(const TypeMatcher<TypeError>()));
     });
 
     test(
@@ -178,7 +176,7 @@ void main() {
         'using `throwOnMissingStub` behavior', () {
       throwOnMissingStub(mock);
       expect(() => mock.nonNullableReturn(43),
-          throwsA(TypeMatcher<MissingStubError>()));
+          throwsA(const TypeMatcher<MissingStubError>()));
     });
   });
 

--- a/test/mockito_test.dart
+++ b/test/mockito_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ignore_for_file: unreachable_from_main
+
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -68,11 +70,7 @@ void main() {
     mock = _MockedClass();
   });
 
-  tearDown(() {
-    // In some of the tests that expect an Error to be thrown, Mockito's
-    // global state can become invalid. Reset it.
-    resetMockitoState();
-  });
+  tearDown(resetMockitoState);
 
   group('mixin support', () {
     test('should work', () {
@@ -297,7 +295,7 @@ void main() {
       when(mock.methodWithNormalArgs(42)).thenReturn('Ultimate Answer');
       expect(
         () => mock.methodWithoutArgs(),
-        throwsA(TypeMatcher<MissingStubError>()),
+        throwsA(const TypeMatcher<MissingStubError>()),
       );
     });
 

--- a/test/nnbd_support_test.dart
+++ b/test/nnbd_support_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ignore_for_file: unreachable_from_main
+
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -36,11 +38,7 @@ void main() {
     mock = MockFoo();
   });
 
-  tearDown(() {
-    // In some of the tests that expect an Error to be thrown, Mockito's
-    // global state can become invalid. Reset it.
-    resetMockitoState();
-  });
+  tearDown(resetMockitoState);
 
   group('Using nSM out of the box,', () {
     test('nSM returns the dummy value during method stubbing', () {

--- a/test/until_called_test.dart
+++ b/test/until_called_test.dart
@@ -73,11 +73,7 @@ void main() {
     mock = _MockedClass();
   });
 
-  tearDown(() {
-    // In some of the tests that expect an Error to be thrown, Mockito's
-    // global state can become invalid. Reset it.
-    resetMockitoState();
-  });
+  tearDown(resetMockitoState);
 
   group('untilCalled', () {
     final streamController = StreamController<CallMethodsEvent>.broadcast();

--- a/test/verify_test.dart
+++ b/test/verify_test.dart
@@ -74,11 +74,7 @@ void main() {
     mock = _MockedClass();
   });
 
-  tearDown(() {
-    // In some of the tests that expect an Error to be thrown, Mockito's
-    // global state can become invalid. Reset it.
-    resetMockitoState();
-  });
+  tearDown(resetMockitoState);
 
   group('verify', () {
     test('should verify method without args', () {
@@ -184,7 +180,7 @@ void main() {
     });
 
     test('should throw meaningful errors when verification is interrupted', () {
-      int badHelper() => throw 'boo';
+      int badHelper() => throw Exception('boo');
 
       try {
         verify(mock.methodWithNamedArgs(42, y: badHelper()));


### PR DESCRIPTION
I am unsure to what version to bump this, as it technically changes the API by adding types to `reset` and `clearInteractions`. 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
