### PR TITLE
Resolve for typedefs/aliases and records in `typeArguments` & resolve duplicate typedefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Require dart_style >= 2.3.7, so that the current Dart language version can be
   passed to `DartFormatter`.
 * Add topics to `pubspec.yaml`.
-* Fix a bug where typedef-aliases in type arguments were not correctly
+* Fix a bug where type aliases in type arguments were not correctly
   resolved.
 * Fix a bug where record types were not correctly resolved.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Require dart_style >= 2.3.7, so that the current Dart language version can be
   passed to `DartFormatter`.
 * Add topics to `pubspec.yaml`.
+* Fix a bug where typedef-aliases in type arguments were not correctly
+  resolved.
+* Fix a bug where record types were not correctly resolved.
 
 ## 5.4.4
 

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -173,6 +173,10 @@ $rawOutput
     void addTypesFrom(analyzer.DartType type) {
       // Prevent infinite recursion.
       if (seenTypes.contains(type)) {
+        if (type.alias != null) {
+          // To check for duplicate typdefs that have different names
+          type.alias!.element.accept(typeVisitor);
+        }
         return;
       }
       seenTypes.add(type);

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -180,10 +180,14 @@ $rawOutput
         return;
       }
       seenTypes.add(type);
-      librariesWithTypes.addAll([
-        if (type.element?.library != null) type.element!.library!,
-        if (type.alias?.element.library != null) type.alias!.element.library,
-      ]);
+
+      if (type.element?.library case var library?) {
+        librariesWithTypes.add(library);
+      }
+      if (type.alias?.element.library case var library?) {
+        librariesWithTypes.add(library);
+      }
+
       type.element?.accept(typeVisitor);
       type.alias?.element.accept(typeVisitor);
       switch (type) {

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -317,6 +317,7 @@ class _TypeVisitor extends RecursiveElementVisitor<void> {
 
   @override
   void visitTypeAliasElement(TypeAliasElement element) {
+    _addType(element.aliasedType);
     _elements.add(element);
     super.visitTypeAliasElement(element);
   }

--- a/test/builder/auto_mocks_test.dart
+++ b/test/builder/auto_mocks_test.dart
@@ -3554,8 +3554,7 @@ void main() {
         expect(mocksContent, contains('implements _i2.Baz'));
       });
 
-      test(
-          'when a type parameter is a typedef a function which returns another type',
+      test('when its a type parameter of function which returns another type',
           () async {
         final mocksContent = await buildWithNonNullable({
           ...annotationsAsset,
@@ -3570,6 +3569,34 @@ void main() {
 
             class Foo extends BaseFoo<CreateBar> {
               Foo() : super(() => 1);
+            }
+          '''),
+          'foo|test/foo_test.dart': '''
+            import 'package:foo/foo.dart';
+            import 'package:mockito/annotations.dart';
+
+            @GenerateMocks([Foo])
+            void main() {}
+          '''
+        });
+
+        expect(mocksContent, contains('class MockFoo extends _i1.Mock'));
+        expect(mocksContent, contains('implements _i2.Foo'));
+      });
+      test('when its a duplicate type parameter', () async {
+        final mocksContent = await buildWithNonNullable({
+          ...annotationsAsset,
+          'foo|lib/foo.dart': dedent(r'''
+            class Bar {}
+            typedef BarDef = int Function();
+            typedef BarDef2 = int Function();
+            class BaseFoo<T,P> {
+              BaseFoo(this.t1, this.t2);
+              final T t1;
+              final P t2;
+            }
+            class Foo extends BaseFoo<BarDef, BarDef2> {
+              Foo() : super(() => 1, () => 2);
             }
           '''),
           'foo|test/foo_test.dart': '''

--- a/test/builder/auto_mocks_test.dart
+++ b/test/builder/auto_mocks_test.dart
@@ -3553,6 +3553,34 @@ void main() {
         expect(mocksContent, contains('class MockBaz extends _i1.Mock'));
         expect(mocksContent, contains('implements _i2.Baz'));
       });
+
+      test('when a type parameter is a typedef a function', () async {
+        final mocksContent = await buildWithNonNullable({
+          ...annotationsAsset,
+          'foo|lib/foo.dart': dedent(r'''
+            typedef CreateInt = int Function();
+
+            class BaseFoo<T> {
+              BaseFoo(this.t);
+              final T t;
+            }
+
+            class Foo extends BaseFoo<CreateInt> {
+              Foo() : super(() => 1);
+            }
+          '''),
+          'foo|test/foo_test.dart': '''
+            import 'package:foo/foo.dart';
+            import 'package:mockito/annotations.dart';
+
+            @GenerateMocks([Foo])
+            void main() {}
+          '''
+        });
+
+        expect(mocksContent, contains('class MockFoo extends _i1.Mock'));
+        expect(mocksContent, contains('implements _i2.Foo'));
+      });
     });
 
     test('generation throws when the aliased type is nullable', () {
@@ -3619,6 +3647,54 @@ void main() {
               contains('Future<(int, {_i2.Bar bar})> get v'),
               contains('returnValue: _i3.Future<(int, {_i2.Bar bar})>.value('),
               contains('bar: _FakeBar_0('))));
+    });
+    test('are supported as typedefs', () async {
+      final mocksContent = await buildWithNonNullable({
+        ...annotationsAsset,
+        'foo|lib/foo.dart': dedent(r'''
+          class Bar {}
+          class BaseFoo<T> {
+            BaseFoo(this.t);
+            final T t;
+          }
+          class Foo extends BaseFoo<(Bar, Bar)> {
+            Foo() : super((Bar(), Bar()));
+          }
+          '''),
+        'foo|test/foo_test.dart': '''
+            import 'package:foo/foo.dart';
+            import 'package:mockito/annotations.dart';
+            @GenerateMocks([Foo])
+            void main() {}
+          '''
+      });
+
+      expect(mocksContent, contains('class MockFoo extends _i1.Mock'));
+      expect(mocksContent, contains('implements _i2.Foo'));
+    });
+    test('are supported as nested typedefs', () async {
+      final mocksContent = await buildWithNonNullable({
+        ...annotationsAsset,
+        'foo|lib/foo.dart': dedent(r'''
+            class Bar {}
+            class BaseFoo<T> {
+              BaseFoo(this.t);
+              final T t;
+            }
+            class Foo extends BaseFoo<(int, (Bar, Bar))> {
+              Foo() : super(((1, (Bar(), Bar()))));
+            }
+          '''),
+        'foo|test/foo_test.dart': '''
+            import 'package:foo/foo.dart';
+            import 'package:mockito/annotations.dart';
+            @GenerateMocks([Foo])
+            void main() {}
+          '''
+      });
+
+      expect(mocksContent, contains('class MockFoo extends _i1.Mock'));
+      expect(mocksContent, contains('implements _i2.Foo'));
     });
   });
 

--- a/test/builder/auto_mocks_test.dart
+++ b/test/builder/auto_mocks_test.dart
@@ -3610,6 +3610,8 @@ void main() {
 
         expect(mocksContent, contains('class MockFoo extends _i1.Mock'));
         expect(mocksContent, contains('implements _i2.Foo'));
+        expect(mocksContent, contains('_i2.BarDef get t1'));
+        expect(mocksContent, contains('_i2.BarDef2 get t2'));
       });
     });
 

--- a/test/builder/auto_mocks_test.dart
+++ b/test/builder/auto_mocks_test.dart
@@ -3554,18 +3554,21 @@ void main() {
         expect(mocksContent, contains('implements _i2.Baz'));
       });
 
-      test('when a type parameter is a typedef a function', () async {
+      test(
+          'when a type parameter is a typedef a function which returns another type',
+          () async {
         final mocksContent = await buildWithNonNullable({
           ...annotationsAsset,
           'foo|lib/foo.dart': dedent(r'''
-            typedef CreateInt = int Function();
+            class Bar {}
+            typedef CreateBar = Bar Function();
 
             class BaseFoo<T> {
               BaseFoo(this.t);
               final T t;
             }
 
-            class Foo extends BaseFoo<CreateInt> {
+            class Foo extends BaseFoo<CreateBar> {
               Foo() : super(() => 1);
             }
           '''),

--- a/test/builder/auto_mocks_test.dart
+++ b/test/builder/auto_mocks_test.dart
@@ -3554,8 +3554,7 @@ void main() {
         expect(mocksContent, contains('implements _i2.Baz'));
       });
 
-      test('when its a type parameter of function which returns another type',
-          () async {
+      test('when it\'s a function which returns any type', () async {
         final mocksContent = await buildWithNonNullable({
           ...annotationsAsset,
           'foo|lib/foo.dart': dedent(r'''
@@ -3583,14 +3582,15 @@ void main() {
         expect(mocksContent, contains('class MockFoo extends _i1.Mock'));
         expect(mocksContent, contains('implements _i2.Foo'));
       });
-      test('when its a duplicate type parameter', () async {
+      test('when the underlying type is identical to another type alias',
+          () async {
         final mocksContent = await buildWithNonNullable({
           ...annotationsAsset,
           'foo|lib/foo.dart': dedent(r'''
             class Bar {}
             typedef BarDef = int Function();
             typedef BarDef2 = int Function();
-            class BaseFoo<T,P> {
+            class BaseFoo<T, P> {
               BaseFoo(this.t1, this.t2);
               final T t1;
               final P t2;
@@ -3678,7 +3678,7 @@ void main() {
               contains('returnValue: _i3.Future<(int, {_i2.Bar bar})>.value('),
               contains('bar: _FakeBar_0('))));
     });
-    test('are supported as typedefs', () async {
+    test('are supported as type arguments', () async {
       final mocksContent = await buildWithNonNullable({
         ...annotationsAsset,
         'foo|lib/foo.dart': dedent(r'''
@@ -3702,7 +3702,7 @@ void main() {
       expect(mocksContent, contains('class MockFoo extends _i1.Mock'));
       expect(mocksContent, contains('implements _i2.Foo'));
     });
-    test('are supported as nested typedefs', () async {
+    test('are supported as nested type arguments', () async {
       final mocksContent = await buildWithNonNullable({
         ...annotationsAsset,
         'foo|lib/foo.dart': dedent(r'''


### PR DESCRIPTION
Closes: https://github.com/dart-lang/mockito/issues/775 
Closes: https://github.com/dart-lang/mockito/issues/777 
Closes: https://github.com/dart-lang/mockito/issues/778

The fix for these issues is closely related so I've done both of them in a single PR.

- Mockito wasn't checking for typedefs/aliases in `typeArguments`
- it also wasn't looking into records on type args. 
- Typedefs which had the same underlying type were ignored even if the typedef had a different name

These issues cause the dreaded `is missing from the asset URI mapping` error.

See the related issue for a repro of each of these. I've also added regression tests for all of these.

Looking forward to a swift review!

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
