### PR TITLE
Restrict all CI actions to Dart dev channel

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -15,7 +15,7 @@ env:
 permissions: read-all
 
 jobs:
-  # Check code formatting with the stable SDK.
+  # Check code formatting with the dev SDK.
   format:
     runs-on: ubuntu-latest
     strategy:
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: dart-lang/setup-dart@e630b99d28a3b71860378cafdc2a067c71107f94
         with:
-          sdk: 3.5.0
+          sdk: dev
       - id: install
         name: Install dependencies
         run: dart pub get
@@ -37,7 +37,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [3.5.0, dev]
+        # TODO(srawlins): Re-enable stable Dart when 3.6.0 is available.
+        #sdk: [3.5.0, dev]
+        sdk: [dev]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: dart-lang/setup-dart@e630b99d28a3b71860378cafdc2a067c71107f94
@@ -59,7 +61,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        sdk: [3.5.0, dev]
+        # TODO(srawlins): Re-enable stable Dart when 3.6.0 is available.
+        #sdk: [3.5.0, dev]
+        sdk: [dev]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: dart-lang/setup-dart@e630b99d28a3b71860378cafdc2a067c71107f94
@@ -75,7 +79,11 @@ jobs:
         run: dart run build_runner build --fail-on-severe
         if: always() && steps.install.outcome == 'success'
       - name: Run DDC tests
-        run: dart run build_runner test -- --platform chrome
+        # We run with `--concurrency=1` because of a bug in the test package,
+        # I believe: https://github.com/dart-lang/test/issues/2294. We can
+        # look into removing this flag when we are using a version of the test
+        # package without this bug.
+        run: dart run build_runner test -- --platform chrome --concurrency=1
         if: always() && steps.install.outcome == 'success'
 
   document:


### PR DESCRIPTION
Recent analyzer APIs are only available with analyzer compatible with Dart ^3.6.0.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
