### PR TITLE
Revert "Update README.md before archiving"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-> [!IMPORTANT]  
-> This repo has moved to https://github.com/dart-lang/test/tree/master/pkgs/mockito
-
 [![Dart CI](https://github.com/dart-lang/mockito/actions/workflows/test-package.yml/badge.svg)](https://github.com/dart-lang/mockito/actions/workflows/test-package.yml)
 [![Pub](https://img.shields.io/pub/v/mockito.svg)](https://pub.dev/packages/mockito)
 [![package publisher](https://img.shields.io/pub/publisher/mockito.svg)](https://pub.dev/packages/mockito/publisher)


### PR DESCRIPTION
Reverting this as we don't want to move this package into a monorepo for the moment; https://github.com/dart-lang/test/pull/2293#issuecomment-2552107650.