### PR TITLE
Reference Issue #581 in relevant section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,8 @@ with `when(cat.sound())`, so what should the code do? What is the "missing stub"
 behavior?
 
 * The "missing stub" behavior of a mock class generated with `@GenerateMocks` is
-  to throw an exception.
+  to throw an exception (with the exception of methods that return
+  `Future<void>` – see https://github.com/dart-lang/mockito/issues/581).
 * The "missing stub" behavior of a mock class generated with
   `@GenerateNiceMocks` is to return a "simple" legal value (for example, a
   non-`null` value for a non-nullable return type). The value should not be used


### PR DESCRIPTION
The README fails to mention a common use case that is an exception to the behavior described around methods that return `Future<void>`. This PR updates the readme with a link to the issue (https://github.com/dart-lang/mockito/issues/581).

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
