### PR TITLE
✨ Fix: Remove redundant // ignore: must_be_immutable in generated mocks

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -1256,7 +1256,6 @@ class _MockClassInfo {
         typeAlias?.element2.aliasedType as analyzer.InterfaceType?;
     final typeToMock = aliasedType ?? mockTarget.classType;
     final classToMock = mockTarget.interfaceElement;
-    final classIsImmutable = classToMock.metadata.any((it) => it.isImmutable);
     final className = aliasedElement?.name3 ?? classToMock.name3;
 
     return Class((cBuilder) {

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -1271,9 +1271,7 @@ class _MockClassInfo {
           '/// See the documentation for Mockito\'s code generation '
           'for more information.',
         );
-      if (classIsImmutable) {
-        cBuilder.docs.add('// ignore: must_be_immutable');
-      }
+
       // For each type parameter on [classToMock], the Mock class needs a type
       // parameter with same type variables, and a mirrored type argument for
       // the "implements" clause.

--- a/test/builder/auto_mocks_test.dart
+++ b/test/builder/auto_mocks_test.dart
@@ -3784,20 +3784,6 @@ void main() {
     );
   });
 
-  test('adds ignore: must_be_immutable analyzer comment if mocked class is '
-      'immutable', () async {
-    await expectSingleNonNullableOutput(
-      dedent(r'''
-      import 'package:meta/meta.dart';
-      @immutable
-      class Foo {
-        void foo();
-      }
-      '''),
-      _containsAllOf('// ignore: must_be_immutable\nclass MockFoo'),
-    );
-  });
-
   group('typedef mocks', () {
     group('are generated properly', () {
       test('when aliased type parameters are instantiated', () async {


### PR DESCRIPTION
This PR addresses issue [#795](https://github.com/dart-lang/mockito/issues/795) by removing the redundant // ignore: must_be_immutable from generated mock files.

Since the directive // ignore_for_file: must_be_immutable is already present at the top of the generated files, the additional per-class // ignore: must_be_immutable is unnecessary and causes a dart(duplicate_ignore) warning.

What this PR does:

Keeps the global ignore directive (ignore_for_file)

Removes the redundant local ignore directives added for immutable classes

Removes the existing test that was checking for the presence of the local directive

This change simplifies the generated code and prevents analyzer warnings related to duplicate ignores.
