### PR TITLE
Versions and build_test 3.0.0 fixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 5.4.7-wip
+## 5.5.0-dev
 
+* Switch to `build` 3.0.0-dev.
 * Require Dart SDK ^3.7.0.
 
 ## 5.4.6

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -937,8 +937,8 @@ class _MockTargetGatherer {
     final className = interfaceElement.name3;
     final substitution = Substitution.fromInterfaceType(mockTarget.classType);
     final relevantMembers = _inheritanceManager
-        .getInterface(interfaceElement)
-        .map
+        .getInterface2(interfaceElement)
+        .map2
         .values
         .where((m) => !m.isPrivate && !m.isStatic)
         .map((member) => ExecutableMember.from(member, substitution));
@@ -1320,8 +1320,8 @@ class _MockClassInfo {
             [...typeToMock.typeArguments, ...?typeAlias?.typeArguments],
           );
           final members = inheritanceManager
-              .getInterface(classToMock)
-              .map
+              .getInterface2(classToMock)
+              .map2
               .values
               .map((member) => ExecutableMember.from(member, substitution));
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 5.4.6
+version: 5.5.0-dev
 description: >-
   A mock framework inspired by Mockito with APIs for Fakes, Mocks,
   behavior verification, and stubbing.
@@ -13,22 +13,23 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  analyzer: '>=6.9.0 <8.0.0'
-  build: ^2.4.1
+  analyzer: '>=7.5.5 <8.0.0'
+  build: ^3.0.0-dev
   code_builder: ^4.5.0
   collection: ^1.19.0
   dart_style: '>=2.3.7 <4.0.0'
   matcher: ^0.12.16
   meta: ^1.15.0
   path: ^1.9.0
-  source_gen: ">=1.4.0 <3.0.0"
+  source_gen: ^3.0.0-dev
   test_api: ">=0.6.1 <0.8.0"
 
 dev_dependencies:
-  build_runner: ^2.4.11
-  build_test: ^2.1.7
-  build_web_compilers: ^4.0.11
+  build_runner: ^2.5.0
+  build_test: ^3.3.0-dev.2
+  build_web_compilers: ^4.2.0
   http: ^1.0.0
   lints: ^5.1.0
+  logging: ^1.0.0
   package_config: ^2.1.1
   test: ^1.24.4


### PR DESCRIPTION
There's a small amount of version skew going on, I think they are due to unpublished analyzer changes around inheritanceManager. I'll use a tight version constraint for `analyzer` so what we publish is correct, we can update later as needed. (People won't use this version much anyway as it's a dev version).

Once that small version skew goes away an option for google3 will be to roll in but disable the tests. Getting `build_test` rolled into google3 is on me :)

tl;dr: could we merge this ahead of google3 and publish to pub? I'm happy to help syncing changes in either direction as needed. Thanks!