### PR TITLE
Specify dart format width in generated files

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -117,7 +117,8 @@ class MockBuilder implements Builder {
       // These comments are added after import directives; leading newlines
       // are necessary. Individual rules are still ignored to preserve backwards
       // compatibility with older versions of Dart.
-      b.body.add(Code('\n\n// ignore_for_file: type=lint\n'));
+      b.body.add(Code('\n\n// dart format width=80\n'));
+      b.body.add(Code('// ignore_for_file: type=lint\n'));
       b.body.add(Code('// ignore_for_file: avoid_redundant_argument_values\n'));
       // We might generate a setter without a corresponding getter.
       b.body.add(Code('// ignore_for_file: avoid_setters_without_getters\n'));


### PR DESCRIPTION
Fixes https://github.com/dart-lang/mockito/issues/816

By specifying the width of the generated files, the dart formatter will use that instead of the configured width, therefore not returning an error in pipelines when the config differs.

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
