### PR TITLE
Reland and release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.5.1
+
+* Allow `source_gen: ">=3.0.0 <5.0.0"`.
+
 ## 5.5.0
 
 * Switch to `build` 3.0.0.

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -144,7 +144,9 @@ class MockBuilder implements Builder {
       // The generator has to occasionally implement sealed classes
       b.body.add(Code('// ignore_for_file: subtype_of_sealed_class\n'));
       // The generator has to occasionally implement internal members.
-      b.body.add(Code('// ignore_for_file: invalid_use_of_internal_member\n\n'));
+      b.body.add(
+        Code('// ignore_for_file: invalid_use_of_internal_member\n\n'),
+      );
       b.body.addAll(mockLibraryInfo.fakeClasses);
       b.body.addAll(mockLibraryInfo.mockClasses);
     });

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -1247,16 +1247,15 @@ class _MockClassInfo {
   });
 
   Class _buildMockClass() {
-    final typeAlias = mockTarget.classType.alias;
-    final aliasedElement = typeAlias?.element2;
-    final aliasedType =
-        typeAlias?.element2.aliasedType as analyzer.InterfaceType?;
+    final instantiatedAlias = mockTarget.classType.alias;
+    final aliasElement = instantiatedAlias?.element2;
+    final aliasedType = aliasElement?.aliasedType as analyzer.InterfaceType?;
     final typeToMock = aliasedType ?? mockTarget.classType;
     final classToMock = mockTarget.interfaceElement;
     final classIsImmutable = classToMock.metadata2.annotations.any(
       (it) => it.isImmutable,
     );
-    final className = aliasedElement?.name3 ?? classToMock.name3;
+    final className = aliasElement?.name3 ?? classToMock.name3;
 
     return Class((cBuilder) {
       cBuilder
@@ -1278,9 +1277,9 @@ class _MockClassInfo {
       // the "implements" clause.
 
       final typeParameters =
-          aliasedElement?.typeParameters2 ?? classToMock.typeParameters2;
+          aliasElement?.typeParameters2 ?? classToMock.typeParameters2;
       final typeArguments =
-          typeAlias?.typeArguments ?? typeToMock.typeArguments;
+          instantiatedAlias?.typeArguments ?? typeToMock.typeArguments;
 
       _withTypeParameters(
         mockTarget.hasExplicitTypeArguments ? [] : typeParameters,
@@ -1300,7 +1299,7 @@ class _MockClassInfo {
             TypeReference((b) {
               b
                 ..symbol = className
-                ..url = _typeImport(aliasedElement ?? classToMock)
+                ..url = _typeImport(aliasElement ?? classToMock)
                 ..types.addAll(
                   mockTarget.hasExplicitTypeArguments
                       ? typeArguments.map(_typeReference)
@@ -1313,11 +1312,8 @@ class _MockClassInfo {
           }
 
           final substitution = Substitution.fromPairs2(
-            [
-              ...classToMock.typeParameters2,
-              ...?aliasedElement?.typeParameters2,
-            ],
-            [...typeToMock.typeArguments, ...?typeAlias?.typeArguments],
+            [...classToMock.typeParameters2, ...?aliasElement?.typeParameters2],
+            [...typeToMock.typeArguments, ...?instantiatedAlias?.typeArguments],
           );
           final members = inheritanceManager
               .getInterface2(classToMock)

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -142,7 +142,9 @@ class MockBuilder implements Builder {
       // The generator appends a suffix to fake classes
       b.body.add(Code('// ignore_for_file: camel_case_types\n'));
       // The generator has to occasionally implement sealed classes
-      b.body.add(Code('// ignore_for_file: subtype_of_sealed_class\n\n'));
+      b.body.add(Code('// ignore_for_file: subtype_of_sealed_class\n'));
+      // The generator has to occasionally implement internal members.
+      b.body.add(Code('// ignore_for_file: invalid_use_of_internal_member\n\n'));
       b.body.addAll(mockLibraryInfo.fakeClasses);
       b.body.addAll(mockLibraryInfo.mockClasses);
     });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,8 +21,8 @@ dependencies:
   matcher: ^0.12.16
   meta: ^1.15.0
   path: ^1.9.0
-  source_gen: ^3.0.0
-  test_api: ">=0.6.1 <0.8.0"
+  source_gen: '>=3.0.0 <5.0.0'
+  test_api: '>=0.6.1 <0.8.0'
 
 dev_dependencies:
   build_runner: ^2.5.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 5.5.0
+version: 5.5.1
 description: >-
   A mock framework inspired by Mockito with APIs for Fakes, Mocks,
   behavior verification, and stubbing.


### PR DESCRIPTION
Review and merge https://github.com/dart-lang/mockito/pull/829 first

This relands the PRs that are compatible with analyzer 7, and allows source_gen 4 which I would like to do before the analyzer 8 release.

It turns out mockito uses a method that is not compatible between 7-8 (inheritance manager) so I couldn't find a way to do a 7-8 release. So: do a final release for 7 with this PR, then breaking change and released for 8 and reland everything.